### PR TITLE
residual block w/o default subsampling

### DIFF
--- a/examples/layers/layer_conditional_hint.jl
+++ b/examples/layers/layer_conditional_hint.jl
@@ -22,11 +22,11 @@ CH = ConditionalLayerHINT(nx, ny, n_channel, n_hidden, batchsize)
 Zx, Zy, logdet = CH.forward(X, Y)
 X_, Y_ = CH.inverse(Zx, Zy)
 
-@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)
-@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-5)
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-4)
+@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-4)
 
 # Forward/inverse Y-lane only
 Zy = CH.forward_Y(Y)
 Y_ = CH.inverse_Y(Zy)
 
-@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-5)
+@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-4)

--- a/examples/layers/layer_conditional_residual.jl
+++ b/examples/layers/layer_conditional_residual.jl
@@ -19,78 +19,15 @@ ny_in = 4
 X = glorot_uniform(nx1, nx2, nx_in, batchsize)
 D = glorot_uniform(ny1, ny2, ny_in, batchsize)
 
-# # Residual blocks
-# RB = ConditionalResidualBlock(nx1, nx2, nx_in, ny1, ny2, ny_in, n_hidden, batchsize)
+# Residual blocks
+RB = ConditionalResidualBlock(nx1, nx2, nx_in, ny1, ny2, ny_in, n_hidden, batchsize)
 
-# # Observed data
-# Y, D_ = RB.forward(X, D)
+# Observed data
+Y, D_ = RB.forward(X, D)
 
-# # Set data residual to zero
-# ΔY = Y.*0f0; ΔD = D.*0f0
+# Set data residual to zero
+ΔY = Y.*0f0; ΔD = D.*0f0
 
-# # Backward pass
-# ΔX, ΔD = RB.backward(ΔY, ΔD, X, D)
+# Backward pass
+ΔX, ΔD = RB.backward(ΔY, ΔD, X, D)
 
-
-#######################################################################################################################
-
-
-# Dense map
-W0 = glorot_uniform(nx1*nx2*nx_in, ny1*ny2*ny_in)
-b0 = zeros(Float32, nx1*nx2*nx_in)
-Y0 = W0*reshape(D, :, batchsize) .+ b0
-
-# Conv map
-k1 = 3
-s1 = 1
-p1 = 1
-W1 = glorot_uniform(k1, k1, nx_in, n_hidden)
-b1 = zeros(Float32, n_hidden)
-cdims1 = DenseConvDims((nx1, nx2, nx_in, batchsize), (k1, k1, nx_in, n_hidden); stride=(s1,s1), padding=(p1,p1))
-X_ = conv(X, W1, cdims1)
-
-
-#######################################################################################################################
-
-
-function get_stride_padding(nx, ny, k)
-    
-    # Check dimensions
-    if mod(nx, 2) != 0 || mod(ny, 2) != 0
-        throw("Dimensions must be even integers.")
-    end
-    
-    if nx == ny
-        stride = 1
-        pad_y = 0
-        pad_x = Int((k-1)/2)
-        is_transpose = false
-    elseif nx > ny
-        stride = Int(floor(nx/ny))
-        pad_y = Int((nx - ny*stride)/2)
-        pad_x = Int((k - mod(k,2))/2)
-        is_transpose = false
-    elseif nx < ny
-        stride = Int(floor(ny/nx))
-        pad_x = Int((ny - nx*stride)/2) + Int((k - mod(k,2))/2)
-        pad_y = 0
-        is_transpose = true
-    else
-        throw("Encountered exception during dimensionality check.")
-    end
-
-    return stride, pad_y, pad_x, is_transpose
-end
-
-function get_conv_dims(nx1, nx2, nx_in, ny1, ny2, ny_in, batchsize; k1=3, k2=3)
-
-    s1, py1, px1, is_transpose = get_stride_padding(nx1, ny1, k1)
-    s2, py2, px2, is_transpose = get_stride_padding(nx2, ny2, k2)
-
-    cdims = DenseConvDims((nx1, nx2, nx_in, batchsize), (k1, k2, nx_in, ny_in); stride=(s1, s2), padding=(px1, px2))
-    return cdims, is_transpose
-end
-
-cdims, is_transpose = get_conv_dims(nx1, nx2, nx_in, ny1, ny2, ny_in, batchsize; k1=3, k2=3)
-W1 = randn(Float32, 3, 3, nx_in, ny_in)
-Y = conv(X, W1, cdims)

--- a/examples/layers/layer_coupling_glow.jl
+++ b/examples/layers/layer_coupling_glow.jl
@@ -11,8 +11,6 @@ k = 20
 n_in = 10
 n_hidden = 20
 batchsize = 2
-k1 = 4
-k2 = 3
 
 # Input image
 X = glorot_uniform(nx, ny, k, batchsize)
@@ -20,7 +18,7 @@ X0 = glorot_uniform(nx, ny, k, batchsize)
 
 # 1x1 convolution and residual blocks
 C = Conv1x1(k)
-RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, fan=true)
+RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; fan=true)
 
 # Invertible splitting layer
 L = CouplingLayerGlow(C, RB; logdet=true)   # compute logdet

--- a/examples/layers/layer_coupling_hint.jl
+++ b/examples/layers/layer_coupling_hint.jl
@@ -25,7 +25,7 @@ HL1 = CouplingLayerHINT(nx, ny, n_channel, n_hidden, batchsize; logdet=false, pe
 Y = HL1.forward(X)
 X_ = HL1.inverse(Y)
 
-@test isapprox(norm(X_ - X)/norm(X), 0f0; atol=1f-6)
+@test isapprox(norm(X_ - X)/norm(X), 0f0; atol=1f-5)
 
 
 ###################################################################################################
@@ -37,7 +37,7 @@ HL2 = CouplingLayerHINT(nx, ny, n_channel, n_hidden, batchsize; logdet=true, per
 Y, logdet = HL2.forward(X)
 X_ = HL2.inverse(Y)
 
-@test isapprox(norm(X_ - X)/norm(X), 0f0; atol=1f-6)
+@test isapprox(norm(X_ - X)/norm(X), 0f0; atol=1f-5)
 
 
 ###################################################################################################
@@ -49,4 +49,4 @@ HL3 = CouplingLayerHINT(nx, ny, n_channel, n_hidden, batchsize; logdet=true, per
 Y, logdet = HL3.forward(X)
 X_ = HL3.inverse(Y)
 
-@test isapprox(norm(X_ - X)/norm(X), 0f0; atol=1f-6)
+@test isapprox(norm(X_ - X)/norm(X), 0f0; atol=1f-5)

--- a/examples/layers/layer_coupling_irim.jl
+++ b/examples/layers/layer_coupling_irim.jl
@@ -11,8 +11,6 @@ k = 20
 n_in = 10
 n_hidden = 20
 batchsize = 2
-k1 = 4
-k2 = 3
 
 # Input image
 X = glorot_uniform(nx, ny, k, batchsize)
@@ -20,7 +18,7 @@ X0 = glorot_uniform(nx, ny, k, batchsize)
 
 # 1x1 convolution and residual blocks
 C = Conv1x1(k)
-RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2)
+RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize)
 
 # Invertible i-RIM coupling layer
 L = CouplingLayerIRIM(C, RB)

--- a/examples/layers/layer_coupling_slim.jl
+++ b/examples/layers/layer_coupling_slim.jl
@@ -33,11 +33,11 @@ L1 = AdditiveCouplingLayerSLIM(nx, ny, n_in, n_hidden, batchsize, Ψ; logdet=tru
 Y, logdet = L1.forward(X, D, A)
 X_ = L1.inverse(Y, D, A)
 @test iszero(logdet)
-@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-6)
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)
 
 ΔY = Y .* 0f0
 X_ = L1.backward(ΔY, Y, D, A)[3]
-@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-6)
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)
 
 
 ###################################################################################################
@@ -49,8 +49,8 @@ L2 = AffineCouplingLayerSLIM(nx, ny, n_in, n_hidden, batchsize, Ψ; logdet=true,
 Y, logdet = L2.forward(X, D, A)
 X_ = L2.inverse(Y, D, A)
 @test ~iszero(logdet)
-@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-6)
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)
 
 ΔY = Y .* 0f0
 X_ = L2.backward(ΔY, Y, D, A)[3]
-@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-6)
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)

--- a/examples/layers/layer_residual_block.jl
+++ b/examples/layers/layer_residual_block.jl
@@ -10,15 +10,30 @@ ny = 64
 n_in = 10
 n_hidden = 20
 batchsize = 2
-k1 = 4
-k2 = 3
+
+# Residual blocks of various networks
+architecture = "Glow"
+
+if architecture == "Glow"
+    # Glow
+    k1 = 3; p1 = 1; s1 = 1
+    k2 = 1; p2 = 0; s2 = 1
+elseif architecture == "HINT"
+    # HINT
+    k1 = 3; p1 = 1; s1 = 1  # standard res-net block
+    k2 = 3; p2 = 1; s2 = 1
+elseif architecture == "iRIM"
+    # i-RIM
+    k1 = 4; p1 = 0; s1 = 4  # downsampling/upsampling in first and third layer
+    k2 = 3; p2 = 1; s2 = 1  # Standard res-net in center layer
+end
 
 # Input image
 X = glorot_uniform(nx, ny, n_in, batchsize)
 
 # Residual blocks
-RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2)
-RB0 = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2)
+RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2)
+RB0 = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2)
 
 # Observed data
 Y = RB.forward(X)

--- a/src/conditional_layers/conditional_layer_hint.jl
+++ b/src/conditional_layers/conditional_layer_hint.jl
@@ -5,7 +5,7 @@
 export ConditionalLayerHINT
 
 """
-    CH = ConditionalLayerHINT(nx, ny, n_in, n_hidden, batchsize; k1=1, k2=3, p1=1, p2=0, permute=true)
+    CH = ConditionalLayerHINT(nx, ny, n_in, n_hidden, batchsize; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, permute=true)
 
  Create a conditional HINT layer based on coupling blocks and 1 level recursion. 
 
@@ -19,6 +19,8 @@ export ConditionalLayerHINT
     operator, `k2` is the kernel size of the second operator.
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
 
  - `permute`: bool to indicate whether to permute `X` and `Y`. Default is `true`
 
@@ -61,12 +63,12 @@ struct ConditionalLayerHINT <: NeuralNetLayer
 end
 
 # Constructor from input dimensions
-function ConditionalLayerHINT(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64; k1=4, k2=3, p1=0, p2=1, permute=true)
+function ConditionalLayerHINT(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, permute=true)
 
     # Create basic coupling layers
-    CL_X = CouplingLayerHINT(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, logdet=true, permute="none")
-    CL_Y = CouplingLayerHINT(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, logdet=true, permute="none")
-    CL_YX = CouplingLayerBasic(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, logdet=true)
+    CL_X = CouplingLayerHINT(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=true, permute="none")
+    CL_Y = CouplingLayerHINT(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=true, permute="none")
+    CL_YX = CouplingLayerBasic(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=true)
 
     # Permutation using 1x1 convolution
     permute == true ? (C_X = Conv1x1(n_in)) : (C_X = nothing)

--- a/src/conditional_layers/conditional_layer_slim.jl
+++ b/src/conditional_layers/conditional_layer_slim.jl
@@ -5,7 +5,8 @@
 export ConditionalLayerSLIM
 
 """
-    CI = ConditionalLayerSLIM(nx1, nx2, nx_in, nx_hidden, ny1, ny2, ny_in, ny_hidden, batchsize, Op; type="affine", k1=4, k2=3, p1=1, p2=0)
+    CI = ConditionalLayerSLIM(nx1, nx2, nx_in, nx_hidden, ny1, ny2, ny_in, ny_hidden, batchsize, Op;
+        type="affine", k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
  Create a conditional SLIM layer based on the HINT architecture.
 
@@ -70,18 +71,23 @@ end
 
 # Constructor from input dimensions
 function ConditionalLayerSLIM(nx1::Int64, nx2::Int64, nx_in::Int64, nx_hidden::Int64, ny1::Int64, ny2::Int64, ny_in::Int64, ny_hidden::Int64,
-    batchsize::Int64; type="affine", k1=4, k2=3, p1=0, p2=1)
+    batchsize::Int64; type="affine", k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
     # Create basic coupling layers
-    CL_X = CouplingLayerHINT(nx1, nx2, nx_in, nx_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, logdet=true)
-    CL_Y = CouplingLayerHINT(Int(ny1/2), Int(ny2/2), Int(ny_in*4), ny_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, logdet=true)
+    CL_X = CouplingLayerHINT(nx1, nx2, nx_in, nx_hidden, batchsize; 
+        k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=true)
+    CL_Y = CouplingLayerHINT(Int(ny1/2), Int(ny2/2), Int(ny_in*4), ny_hidden, batchsize; 
+        k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=true)
     
     if type == "affine"
-        CL_XY = AffineCouplingLayerSLIM(nx1, nx2, nx_in, nx_hidden, batchsize, identity; k1=k1, k2=k2, logdet=true, permute=false)
+        CL_XY = AffineCouplingLayerSLIM(nx1, nx2, nx_in, nx_hidden, batchsize, identity;
+            k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=true, permute=false)
     elseif type == "additive"
-        CL_XY = AdditiveCouplingLayerSLIM(nx1, nx2, nx_in, nx_hidden, batchsize, identity; k1=k1, k2=k2, logdet=true, permute=false)
+        CL_XY = AdditiveCouplingLayerSLIM(nx1, nx2, nx_in, nx_hidden, batchsize, identity;
+            k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=true, permute=false)
     elseif type == "learned"
-        CL_XY = LearnedCouplingLayerSLIM( nx1, nx2, nx_in, ny1, ny2, ny_in, nx_hidden, batchsize; k1=k1, k2=k2, logdet=true, permute=false)
+        CL_XY = LearnedCouplingLayerSLIM( nx1, nx2, nx_in, ny1, ny2, ny_in, nx_hidden, batchsize;
+            k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=true, permute=false)
     else
         throw("Specified layer type not defined.")
     end

--- a/src/layers/invertible_layer_basic.jl
+++ b/src/layers/invertible_layer_basic.jl
@@ -11,7 +11,7 @@ export CouplingLayerBasic
 
 or
 
-    CL = CouplingLayerBasic(nx, ny, n_in, n_hidden, batchsize; k1=1, k2=3, p1=0, p2=1, logdet=false)
+    CL = CouplingLayerBasic(nx, ny, n_in, n_hidden, batchsize; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, logdet=false)
 
  Create a Real NVP-style invertible coupling layer with a residual block. 
 
@@ -31,6 +31,8 @@ or
     operator, `k2` is the kernel size of the second operator.
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s1`)
 
  *Output*:
  
@@ -71,10 +73,10 @@ function CouplingLayerBasic(RB::ResidualBlock; logdet=false)
 end
 
 # Constructor from input dimensions
-function CouplingLayerBasic(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64; k1=3, k2=1, p1=1, p2=0, logdet=false)
+function CouplingLayerBasic(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, logdet=false)
 
     # 1x1 Convolution and residual block for invertible layer
-    RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, fan=true)
+    RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, fan=true)
 
     return CouplingLayerBasic(RB, logdet,
         (X1, X2) -> coupling_layer_forward(X1, X2, RB, logdet),

--- a/src/layers/invertible_layer_glow.jl
+++ b/src/layers/invertible_layer_glow.jl
@@ -11,7 +11,7 @@ export CouplingLayerGlow
 
 or
 
-    CL = CouplingLayerGlow(nx, ny, n_in, n_hidden, batchsize; k1=1, k2=3, p1=0, p2=1, logdet=false)
+    CL = CouplingLayerGlow(nx, ny, n_in, n_hidden, batchsize; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1, logdet=false)
 
  Create a Real NVP-style invertible coupling layer based on 1x1 convolutions and a residual block. 
 
@@ -33,6 +33,8 @@ or
     operator, `k2` is the kernel size of the second operator.
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
 
  *Output*:
  
@@ -74,11 +76,11 @@ function CouplingLayerGlow(C::Conv1x1, RB::ResidualBlock; logdet=false)
 end
 
 # Constructor from input dimensions
-function CouplingLayerGlow(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64; k1=3, k2=1, p1=1, p2=0, logdet=false)
+function CouplingLayerGlow(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1, logdet=false)
 
     # 1x1 Convolution and residual block for invertible layer
     C = Conv1x1(n_in)
-    RB = ResidualBlock(nx, ny, Int(n_in/2), n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, fan=true)
+    RB = ResidualBlock(nx, ny, Int(n_in/2), n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, fan=true)
 
     return CouplingLayerGlow(C, RB, logdet,
         X -> coupling_layer_forward(X, C, RB, logdet),

--- a/src/layers/invertible_layer_hint.jl
+++ b/src/layers/invertible_layer_hint.jl
@@ -5,7 +5,7 @@
 export CouplingLayerHINT
 
 """
-    H = CouplingLayerHINT(nx, ny, n_in, n_hidden, batchsize; logdet=false, permute="none", k1=1, k2=3, p1=1, p2=0)
+    H = CouplingLayerHINT(nx, ny, n_in, n_hidden, batchsize; logdet=false, permute="none", k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
  Create a recursive HINT-style invertible layer based on coupling blocks. 
 
@@ -23,6 +23,8 @@ export CouplingLayerHINT
     operator, `k2` is the kernel size of the second operator.
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
 
  *Output*:
  
@@ -65,13 +67,13 @@ function get_depth(n_in)
 end
 
 # Constructor from input dimensions
-function CouplingLayerHINT(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64; logdet=false, permute="none", k1=4, k2=3, p1=0, p2=1)
+function CouplingLayerHINT(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64; logdet=false, permute="none", k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
     # Create basic coupling layers
     n = get_depth(n_in)
     CL = Array{CouplingLayerBasic}(undef, n) 
     for j=1:n
-        CL[j] = CouplingLayerBasic(nx, ny, Int(n_in/2^j), n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, logdet=logdet)
+        CL[j] = CouplingLayerBasic(nx, ny, Int(n_in/2^j), n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=logdet)
     end
 
     # Permutation using 1x1 convolution

--- a/src/layers/invertible_layer_irim.jl
+++ b/src/layers/invertible_layer_irim.jl
@@ -9,7 +9,7 @@ export CouplingLayerIRIM
 
 or
 
-    IL = CouplingLayerIRIM(nx, ny, n_in, n_hidden, batchsize; k1=3, k2=1, p1=1, p2=0, logdet=false)
+    IL = CouplingLayerIRIM(nx, ny, n_in, n_hidden, batchsize; k1=4, k2=3, p1=0, p2=1, s1=4, s2=1, logdet=false)
 
  Create an i-RIM invertible coupling layer based on 1x1 convolutions and a residual block. 
 
@@ -29,6 +29,8 @@ or
     operator, `k2` is the kernel size of the second operator.
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
 
  *Output*:
  
@@ -68,11 +70,11 @@ function CouplingLayerIRIM(C::Conv1x1, RB::ResidualBlock)
 end
 
 # Constructor from input dimensions
-function CouplingLayerIRIM(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64; k1=4, k2=3, p1=0, p2=1)
+function CouplingLayerIRIM(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64; k1=4, k2=3, p1=0, p2=1, s1=4, s2=1)
 
     # 1x1 Convolution and residual block for invertible layer
     C = Conv1x1(n_in)
-    RB = ResidualBlock(nx, ny, Int(n_in/2), n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2)
+    RB = ResidualBlock(nx, ny, Int(n_in/2), n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2)
 
     return CouplingLayerIRIM(C, RB, 
         X -> inv_layer_forward(X, C, RB),

--- a/src/layers/invertible_layer_slim_additive.jl
+++ b/src/layers/invertible_layer_slim_additive.jl
@@ -7,7 +7,7 @@ export AdditiveCouplingLayerSLIM
 
 
 """
-    CS = AdditiveCouplingLayerSLIM(nx, ny, n_in, n_hidden, batchsize, Ψ; logdet=false, permute=false, k1=1, k2=3, p1=0, p2=1, )
+    CS = AdditiveCouplingLayerSLIM(nx, ny, n_in, n_hidden, batchsize, Ψ; logdet=false, permute=false, k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
  Create an invertible additive SLIM coupling layer.
 
@@ -27,6 +27,8 @@ export AdditiveCouplingLayerSLIM
     operator, `k2` is the kernel size of the second operator
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
 
  *Output*:
  
@@ -64,7 +66,7 @@ end
 
 # Constructor from input dimensions
 function AdditiveCouplingLayerSLIM(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64, Ψ::Function; 
-    k1=4, k2=3, p1=0, p2=1, s1=4, s2=1, logdet::Bool=false, permute::Bool=false)
+    k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, logdet::Bool=false, permute::Bool=false)
 
     # 1x1 Convolution and residual block for invertible layer
     permute == true ? (C = Conv1x1(n_in)) : (C = nothing)

--- a/src/layers/invertible_layer_slim_affine.jl
+++ b/src/layers/invertible_layer_slim_affine.jl
@@ -7,7 +7,7 @@ export AffineCouplingLayerSLIM
 
 
 """
-    CS = AffineCouplingLayerSLIM(nx, ny, n_in, n_hidden, batchsize, Ψ; logdet=false, permute=false, k1=1, k2=3, p1=0, p2=1)
+    CS = AffineCouplingLayerSLIM(nx, ny, n_in, n_hidden, batchsize, Ψ; logdet=false, permute=false, k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
  Create an invertible affine SLIM coupling layer.
 
@@ -27,6 +27,8 @@ export AffineCouplingLayerSLIM
     operator, `k2` is the kernel size of the second operator
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
 
  *Output*:
  
@@ -64,7 +66,7 @@ end
 
 # Constructor from input dimensions
 function AffineCouplingLayerSLIM(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64, Ψ::Function; 
-    k1=4, k2=3, p1=0, p2=1, s1=4, s2=1, logdet::Bool=false, permute::Bool=false)
+    k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, logdet::Bool=false, permute::Bool=false)
 
     # 1x1 Convolution and residual block for invertible layer
     permute == true ? (C = Conv1x1(n_in)) : (C = nothing)

--- a/src/layers/invertible_layer_slim_learned.jl
+++ b/src/layers/invertible_layer_slim_learned.jl
@@ -8,7 +8,7 @@ export LearnedCouplingLayerSLIM
 
 """
     CS = LearnedCouplingLayerSLIM(nx1, nx2, nx_in, ny1, ny2, ny_in, n_hidden, batchsize; 
-        logdet::Bool=false, permute::Bool=false, k1=4, k2=3, p1=0, p2=1, s1=4, s2=1)
+        logdet::Bool=false, permute::Bool=false, k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
  Create an invertible SLIM coupling layer with a learned data-to-image-space map.
 
@@ -65,7 +65,7 @@ end
 
 # Constructor from input dimensions
 function LearnedCouplingLayerSLIM(nx1, nx2, nx_in, ny1, ny2, ny_in, n_hidden, batchsize; 
-    k1=4, k2=3, p1=0, p2=1, s1=4, s2=1, logdet::Bool=false, permute::Bool=false)
+    k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, logdet::Bool=false, permute::Bool=false)
 
     # 1x1 Convolution and residual block for invertible layer
     permute == true ? (C = Conv1x1(nx_in)) : (C = nothing)

--- a/src/networks/invertible_network_conditional_hint.jl
+++ b/src/networks/invertible_network_conditional_hint.jl
@@ -5,7 +5,7 @@
 export NetworkConditionalHINT
 
 """
-    CH = NetworkConditionalHINT(nx, ny, n_in, batchsize, n_hidden, depth; k1=4, k2=3, p1=0, p2=1)
+    CH = NetworkConditionalHINT(nx, ny, n_in, batchsize, n_hidden, depth; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
  Create a conditional HINT network for data-driven generative modeling based
  on the change of variables formula.
@@ -21,6 +21,8 @@ export NetworkConditionalHINT
  - `k1`, `k2`: kernel size for first and third residual layer (`k1`) and second layer (`k2`)
 
  - `p1`, `p2`: respective padding sizes for residual block layers
+
+ - `s1`, `s2`: respective strides for residual block layers
  
  *Output*:
  
@@ -55,7 +57,7 @@ struct NetworkConditionalHINT <: InvertibleNetwork
 end
 
 # Constructor
-function NetworkConditionalHINT(nx, ny, n_in, batchsize, n_hidden, depth; k1=4, k2=3, p1=0, p2=1)
+function NetworkConditionalHINT(nx, ny, n_in, batchsize, n_hidden, depth; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
     AN_X = Array{ActNorm}(undef, depth)
     AN_Y = Array{ActNorm}(undef, depth)
@@ -65,7 +67,7 @@ function NetworkConditionalHINT(nx, ny, n_in, batchsize, n_hidden, depth; k1=4, 
     for j=1:depth
         AN_X[j] = ActNorm(n_in; logdet=true)
         AN_Y[j] = ActNorm(n_in; logdet=true)
-        CL[j] = ConditionalLayerHINT(nx, ny, n_in, n_hidden, batchsize; permute=true, k1=k1, k2=k2, p1=p1, p2=p2)
+        CL[j] = ConditionalLayerHINT(nx, ny, n_in, n_hidden, batchsize; permute=true, k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2)
     end
 
     return NetworkConditionalHINT(AN_X, AN_Y, CL, 

--- a/src/networks/invertible_network_conditional_hint_multiscale.jl
+++ b/src/networks/invertible_network_conditional_hint_multiscale.jl
@@ -5,7 +5,7 @@
 export NetworkMultiScaleConditionalHINT
 
 """
-    CH = NetworkMultiScaleConditionalHINT(nx, ny, n_in, batchsize, n_hidden,  L, K; k1=4, k2=3, p1=0, p2=1)
+    CH = NetworkMultiScaleConditionalHINT(nx, ny, n_in, batchsize, n_hidden,  L, K; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
  Create a conditional HINT network for data-driven generative modeling based
  on the change of variables formula.
@@ -24,6 +24,8 @@ export NetworkMultiScaleConditionalHINT
 
  - `p1`, `p2`: respective padding sizes for residual block layers
  
+ - `s1`, `s2`: respective strides for residual block layers
+
  *Output*:
  
  - `CH`: conditioinal HINT network
@@ -58,7 +60,7 @@ struct NetworkMultiScaleConditionalHINT <: InvertibleNetwork
 end
 
 # Constructor
-function NetworkMultiScaleConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L, K; k1=4, k2=3, p1=0, p2=1)
+function NetworkMultiScaleConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L, K; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
     AN_X = Array{ActNorm}(undef, L, K)
     AN_Y = Array{ActNorm}(undef, L, K)
@@ -70,7 +72,7 @@ function NetworkMultiScaleConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L, 
         for j=1:K
             AN_X[i, j] = ActNorm(n_in*4; logdet=true)
             AN_Y[i, j] = ActNorm(n_in*4; logdet=true)
-            CL[i, j] = ConditionalLayerHINT(Int(nx/2^i), Int(ny/2^i), n_in*4, n_hidden, batchsize; permute=true, k1=k1, k2=k2, p1=p1, p2=p2)
+            CL[i, j] = ConditionalLayerHINT(Int(nx/2^i), Int(ny/2^i), n_in*4, n_hidden, batchsize; permute=true, k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2)
         end
         n_in *= 2
     end

--- a/src/networks/invertible_network_glow.jl
+++ b/src/networks/invertible_network_glow.jl
@@ -6,7 +6,7 @@
 export NetworkGlow
 
 """
-    G = NetworkGlow(nx, ny, n_in, batchsize, n_hidden, L, K)
+    G = NetworkGlow(nx, ny, n_in, batchsize, n_hidden, L, K; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1)
 
  Create an invertible network based on the Glow architecture. Each flow step in the inner loop 
  consists of an activation normalization layer, followed by an invertible coupling layer with
@@ -22,6 +22,13 @@ export NetworkGlow
  - `L`: number of scales (outer loop)
 
  - `K`: number of flow steps per scale (inner loop)
+
+ - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third 
+ operator, `k2` is the kernel size of the second operator.
+
+ - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
 
  *Output*:
  
@@ -52,7 +59,7 @@ struct NetworkGlow <: InvertibleNetwork
 end
 
 # Constructor
-function NetworkGlow(nx, ny, n_in, batchsize, n_hidden, L, K)
+function NetworkGlow(nx, ny, n_in, batchsize, n_hidden, L, K; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1)
 
     AN = Array{ActNorm}(undef, L, K)    # activation normalization
     CL = Array{CouplingLayerGlow}(undef, L, K)  # coupling layers w/ 1x1 convolution and residual block
@@ -61,7 +68,7 @@ function NetworkGlow(nx, ny, n_in, batchsize, n_hidden, L, K)
     for i=1:L
         for j=1:K
             AN[i, j] = ActNorm(n_in; logdet=true)
-            CL[i, j] = CouplingLayerGlow(Int(nx/2^i), Int(ny/2^i), n_in*4, n_hidden, batchsize; k1=1, k2=3, p1=0, p2=1, logdet=true)
+            CL[i, j] = CouplingLayerGlow(Int(nx/2^i), Int(ny/2^i), n_in*4, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=true)
         end
         n_in *= 2
     end

--- a/src/networks/invertible_network_hyperbolic.jl
+++ b/src/networks/invertible_network_hyperbolic.jl
@@ -55,7 +55,7 @@ function NetworkHyperbolic(nx::Int64, ny::Int64, n_in::Int64, batchsize::Int64, 
         k=3, s=1, p=1, logdet=true, α=1f0, hidden_factor=1, ncenter=1)
 
     depth = Int(2*(L-1)*K + ncenter)
-    AL = AffineLayer(Int(nx/4), Int(ny/4), Int(n_in*4); logdet=logdet)
+    AL = AffineLayer(Int(nx/2), Int(ny/2), Int(n_in*4); logdet=logdet)
     HL = Array{HyperbolicLayer}(undef, depth)
     nx = Int(nx/2); ny = Int(ny/2); n_in = Int(n_in*2)  # dimensions after initial wavelet transform
 

--- a/src/networks/invertible_network_irim.jl
+++ b/src/networks/invertible_network_irim.jl
@@ -5,7 +5,7 @@
 export NetworkLoop
 
 """
-    L = NetworkLoop(nx, ny, n_in, n_hidden, batchsize, maxiter, Ψ; k1=4, k2=3)
+    L = NetworkLoop(nx, ny, n_in, n_hidden, batchsize, maxiter, Ψ; k1=4, k2=3, p1=0, p2=1, s1=4, s2=1)
 
  Create an invertibel recurrent inference machine (i-RIM) consisting of an unrooled loop
  for a given number of iterations.
@@ -26,6 +26,12 @@ export NetworkLoop
    but performs the transpose operation of the first convolution, thus upsampling the output to 
    the original input size.
 
+ - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`) in
+   residual block
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`) in
+   residual block
+  
  *Output*:
  
  - `L`: invertible i-RIM network.
@@ -56,12 +62,12 @@ struct NetworkLoop <: InvertibleNetwork
     backward::Function
 end
 
-function NetworkLoop(nx, ny, n_in, n_hidden, batchsize, maxiter, Ψ; k1=4, k2=3, p1=0, p2=1)
+function NetworkLoop(nx, ny, n_in, n_hidden, batchsize, maxiter, Ψ; k1=4, k2=3, p1=0, p2=1, s1=4, s2=1)
     
     L = Array{CouplingLayerIRIM}(undef, maxiter)
     AN = Array{ActNorm}(undef, maxiter)
     for j=1:maxiter
-        L[j] = CouplingLayerIRIM(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=0, p2=1)
+        L[j] = CouplingLayerIRIM(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2)
         AN[j] = ActNorm(1)
     end
     

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@
 
 using InvertibleNetworks, Test
 
-test_suite = "networks"   # "all", "layers" or "networks"
+test_suite = "all"   # "all", "layers" or "networks"
 
 if test_suite == "all" || test_suite == "layers"
     @testset "Test individual layers" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@
 
 using InvertibleNetworks, Test
 
-test_suite = "layers"   # "all", "layers" or "networks"
+test_suite = "networks"   # "all", "layers" or "networks"
 
 if test_suite == "all" || test_suite == "layers"
     @testset "Test individual layers" begin

--- a/test/test_layers/test_conditional_layer_hint.jl
+++ b/test/test_layers/test_conditional_layer_hint.jl
@@ -28,8 +28,8 @@ CH = ConditionalLayerHINT(nx, ny, n_channel, n_hidden, batchsize)
 Zx, Zy, logdet = CH.forward(X, Y)
 X_, Y_ = CH.inverse(Zx, Zy)
 
-@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-6)
-@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-6)
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)
+@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-5)
 
 # Test backward
 Zx, Zy, logdet = CH.forward(X, Y)
@@ -37,14 +37,14 @@ Zx, Zy, logdet = CH.forward(X, Y)
 ΔZy = randn(Float32, size(Zx))
 ΔX_, ΔY_, X_, Y_ = CH.backward(ΔZx, ΔZy, Zx, Zy)
 
-@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-6)
-@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-6)
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)
+@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-5)
 
 # Test inverse Y only
 Zy = CH.forward_Y(Y)
 Y_ = CH.inverse_Y(Zy)
 
-@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-6)
+@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-5)
 
 #######################################################################################################################
 # Gradient test

--- a/test/test_layers/test_coupling_layer_basic.jl
+++ b/test/test_layers/test_coupling_layer_basic.jl
@@ -17,8 +17,6 @@ k = 4
 n_in = 2
 n_hidden = 4
 batchsize = 1
-k1 = 4
-k2 = 3
 
 # Input images
 Xa = randn(Float32, nx, ny, Int(k/2), batchsize)
@@ -29,7 +27,7 @@ dXa = Xa - Xa0
 dXb = Xb - Xb0
 
 # 1x1 convolution and residual blocks
-RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, fan=true)
+RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; fan=true)
 L = CouplingLayerBasic(RB; logdet=true)
 
 ###################################################################################################
@@ -68,7 +66,7 @@ function loss(L, Xa, Xb, Ya, Yb)
 end
 
 # Invertible layers
-RB0 = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, fan=true)
+RB0 = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; fan=true)
 L01 = CouplingLayerBasic(RB; logdet=true)
 L02 = CouplingLayerBasic(RB0; logdet=true)
 

--- a/test/test_layers/test_coupling_layer_glow.jl
+++ b/test/test_layers/test_coupling_layer_glow.jl
@@ -17,8 +17,6 @@ k = 4
 n_in = 2
 n_hidden = 4
 batchsize = 1
-k1 = 4
-k2 = 3
 
 # Input images
 X = randn(Float32, nx, ny, k, batchsize)
@@ -27,7 +25,7 @@ dX = X - X0
 
 # 1x1 convolution and residual blocks
 C = Conv1x1(k)
-RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, fan=true)
+RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=3, k2=3, p1=1, p2=1, fan=true)
 L = CouplingLayerGlow(C, RB; logdet=true)
 
 X_ = L.inverse(L.forward(X)[1])
@@ -52,7 +50,7 @@ end
 
 # Invertible layers
 C0 = Conv1x1(k)
-RB0 = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2, fan=true)
+RB0 = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=3, k2=3, p1=1, p2=1, fan=true)
 L01 = CouplingLayerGlow(C0, RB; logdet=true)
 L02 = CouplingLayerGlow(C, RB0; logdet=true)
 

--- a/test/test_layers/test_coupling_layer_hint.jl
+++ b/test/test_layers/test_coupling_layer_hint.jl
@@ -81,7 +81,7 @@ HLini = deepcopy(HL0)
 dW = HL.CL[1].RB.W1.data - HL0.CL[1].RB.W1.data
 
 f0, gX, gW, X_ = loss(HL0, X)
-@test isapprox(norm(X_ - X)/norm(X), 0f0; atol=1f-6)
+@test isapprox(norm(X_ - X)/norm(X), 0f0; atol=1f-5)
 
 maxiter = 5
 h = 0.5f0
@@ -119,7 +119,7 @@ HLini = deepcopy(HL0)
 dW = HL.CL[1].RB.W1.data - HL0.CL[1].RB.W1.data
 
 f0, gX, gW, X_ = loss_logdet(HL0, X)
-@test isapprox(norm(X_ - X)/norm(X), 0f0; atol=1f-6)
+@test isapprox(norm(X_ - X)/norm(X), 0f0; atol=1f-5)
 
 maxiter = 5
 h = 0.5f0

--- a/test/test_layers/test_coupling_layer_irim.jl
+++ b/test/test_layers/test_coupling_layer_irim.jl
@@ -7,29 +7,19 @@ using InvertibleNetworks, LinearAlgebra, Test
 # Input
 nx = 28
 ny = 28
-k = 8
-n_in = 4
+n_in = 8
 n_hidden = 8
 batchsize = 2
-k1 = 4
-k2 = 3
 
 # Input images
-X = randn(Float32, nx, ny, k, batchsize)
-X0 = randn(Float32, nx, ny, k, batchsize)
+X = randn(Float32, nx, ny, n_in, batchsize)
+X0 = randn(Float32, nx, ny, n_in, batchsize)
 dX = X - X0
 
-# 1x1 convolution and residual blocks
-C = Conv1x1(k)
-RB = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2)
-
-C0 = Conv1x1(k)
-RB0 = ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=k1, k2=k2)
-
-# Invertible layer
-L = CouplingLayerIRIM(C, RB)
-L01 = CouplingLayerIRIM(C0, RB)
-L02 = CouplingLayerIRIM(C, RB0)
+# Invertible layers
+L = CouplingLayerIRIM(nx, ny, n_in, n_hidden, batchsize)
+L01 = CouplingLayerIRIM(nx, ny, n_in, n_hidden, batchsize)
+L02 = CouplingLayerIRIM(nx, ny, n_in, n_hidden, batchsize)
 
 ###################################################################################################
 # Test invertibility
@@ -108,9 +98,9 @@ end
 # Gradient test w.r.t. 1x1 conv weights
 Y = L.forward(X)
 Lini = deepcopy(L01)
-dv1 = C.v1.data - C0.v1.data
-dv2 = C.v2.data - C0.v2.data
-dv3 = C.v3.data - C0.v3.data
+dv1 = L.C.v1.data - L01.C.v1.data
+dv2 = L.C.v2.data - L01.C.v2.data
+dv3 = L.C.v3.data - L01.C.v3.data
 
 f0, ΔX, Δv1, Δv2, Δv3, ΔW1, ΔW2, ΔW3 = loss(L01, X, Y)
 h = 0.1f0

--- a/test/test_layers/test_residual_block.jl
+++ b/test/test_layers/test_residual_block.jl
@@ -10,7 +10,7 @@ ny = 28
 n_in = 4
 n_hidden = 8
 batchsize = 2
-k1 = 4
+k1 = 3
 k2 = 3
 
 # Input

--- a/test/test_networks/test_conditional_hint_network.jl
+++ b/test/test_networks/test_conditional_hint_network.jl
@@ -3,6 +3,7 @@
 # Date: January 2020
 
 using InvertibleNetworks, LinearAlgebra, Test, Random
+Random.seed!(11)
 
 # Define network
 nx = 64
@@ -15,9 +16,9 @@ K = 2
 multiscale = true
 
 if multiscale
-    CH = NetworkMultiScaleConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L, K)
+    CH = NetworkMultiScaleConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L, K; k1=3, k2=1, p1=1, p2=0)
 else
-    CH = NetworkConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L*K)
+    CH = NetworkConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L*K; k1=3, k2=1, p1=1, p2=0)
 end
 
 ###################################################################################################
@@ -31,19 +32,19 @@ Y = X + .1f0*randn(Float32, nx, ny, n_in, test_size)
 # Forward-backward
 Zx, Zy, logdet = CH.forward(X, Y)
 X_, Y_ = CH.backward(0f0.*Zx, 0f0.*Zy, Zx, Zy)[3:4]
-@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)
-@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-5)
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-4)
+@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-4)
 
 # Forward-inverse
 Zx, Zy, logdet = CH.forward(X, Y)
 X_, Y_ = CH.inverse(Zx, Zy)
-@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)
-@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-5)
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-4)
+@test isapprox(norm(Y - Y_)/norm(Y), 0f0; atol=1f-4)
 
 # Y-lane only
 Zyy = CH.forward_Y(Y)
 Yy = CH.inverse_Y(Zyy)
-@test isapprox(norm(Y - Yy)/norm(Y), 0f0; atol=1f-5)
+@test isapprox(norm(Y - Yy)/norm(Y), 0f0; atol=1f-4)
 
 
 ###################################################################################################
@@ -61,9 +62,9 @@ end
 
 # Gradient test w.r.t. input
 if multiscale
-    CH = NetworkMultiScaleConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L, K)
+    CH = NetworkMultiScaleConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L, K; k1=3, k2=1, p1=1, p2=0)
 else
-    CH = NetworkConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L*K)
+    CH = NetworkConditionalHINT(nx, ny, n_in, batchsize, n_hidden, L*K; k1=3, k2=1, p1=1, p2=0)
 end
 
 X = randn(Float32, nx, ny, n_in, test_size)

--- a/test/test_networks/test_generator.jl
+++ b/test/test_networks/test_generator.jl
@@ -2,7 +2,7 @@
 # Author: Philipp Witte, pwitte3@gatech.edu
 # Date: January 2020
 
-using LinearAlgebra, InvertibleNetworks, Flux, Test
+using LinearAlgebra, InvertibleNetworks, Flux, Test, Random
 import Flux.Optimise.update!
 Random.seed!(11)
 

--- a/test/test_networks/test_generator.jl
+++ b/test/test_networks/test_generator.jl
@@ -4,6 +4,7 @@
 
 using LinearAlgebra, InvertibleNetworks, Flux, Test
 import Flux.Optimise.update!
+Random.seed!(11)
 
 # Target distribution
 function swirl(batchsize; noise=.5f0)

--- a/test/test_networks/test_glow.jl
+++ b/test/test_networks/test_glow.jl
@@ -2,7 +2,7 @@
 # Author: Philipp Witte, pwitte3@gatech.edu
 # Date: January 2020
 
-using InvertibleNetworks, LinearAlgebra, Test
+using InvertibleNetworks, LinearAlgebra, Test, Random
 
 # Define network
 nx = 32

--- a/test/test_networks/test_hyperbolic_network.jl
+++ b/test/test_networks/test_hyperbolic_network.jl
@@ -46,7 +46,7 @@ dX = X - X0
 # Gradient test w.r.t. input X0
 Y = H.forward(X)
 f0, ΔX = loss(H, X0)[1:2]
-h = 0.01f0
+h = 0.1f0
 maxiter = 6
 err1 = zeros(Float32, maxiter)
 err2 = zeros(Float32, maxiter)
@@ -75,7 +75,7 @@ dW = H.HL[1].W.data - H0.HL[1].W.data
 ds = H.AL.s.data - H0.AL.s.data
 
 f0, ΔX, ΔW, Δs = loss(H0, X)
-h = 0.1f0
+h = 0.01f0
 maxiter = 6
 err3 = zeros(Float32, maxiter)
 err4 = zeros(Float32, maxiter)

--- a/test/test_networks/test_hyperbolic_network.jl
+++ b/test/test_networks/test_hyperbolic_network.jl
@@ -8,9 +8,6 @@ nx = 16
 ny = 16
 n_in = 3
 batchsize = 4
-k = 3   # kernel size
-s = 1   # stride
-p = 1   # padding
 X = randn(Float32, nx, ny, n_in, batchsize)
 
 # Network
@@ -29,7 +26,7 @@ X_ = H.forward(H.inverse(X))[1]
 @test isapprox(norm(X - X_)/norm(X), 0f0; atol=1e-2)
 
 
-#############################################################################################################
+####################################################################################################
 # Training
 
 # Loss

--- a/test/test_networks/test_unrolled_loop.jl
+++ b/test/test_networks/test_unrolled_loop.jl
@@ -1,4 +1,4 @@
-using InvertibleNetworks, LinearAlgebra, Test
+using InvertibleNetworks, LinearAlgebra, Test, Random
 
 # Input
 nx = 16


### PR DESCRIPTION
Default residual w/o spatial subsampling.

Default for residual block and HINT layers/networks:
**Layer 1**: 3 x 3, padding 1, stride 1
**Layer 2**: 3 x 3, padding 1, stride 1
**Layer 3**: 3 x 3, padding 1, stride 1

Default for glow layer and network:
**Layer 1**: 3 x 3, padding 1, stride 1
**Layer 2**: 1 x 1, padding 0, stride 1
**Layer 3**: 3 x 3, padding 1, stride 1

Default for iRIM layer and network:
**Layer 1**: 4 x 4, padding 0, stride 4 (down)
**Layer 2**: 3 x 3, padding 1, stride 1
**Layer 3**: 4 x 4, padding 0, stride 4 (up)