### PR TITLE
Some fixes and improvements regarding to element-wise operations

### DIFF
--- a/.github/workflows/.runtests.yml
+++ b/.github/workflows/.runtests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        version: ['1.3', '1.4', '1.5', 'nightly']
+        version: ['1.3', '1.4', '1.5']
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/.runtests.yml
+++ b/.github/workflows/.runtests.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches-ignore:
-      - 'gpu'
+      - ''
 
 jobs:
   test:

--- a/.github/workflows/.runtests.yml
+++ b/.github/workflows/.runtests.yml
@@ -1,9 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches-ignore:
-      - ''
+on: push
 
 jobs:
   test:
@@ -40,4 +37,3 @@ jobs:
       - name: Run simple example
         if: runner.os == 'linux'
         run: julia --project examples/layers/layer_actnorm.jl
-

--- a/.github/workflows/.runtests.yml
+++ b/.github/workflows/.runtests.yml
@@ -11,12 +11,8 @@ jobs:
       fail-fast: false
 
       matrix:
-        version:
-          - '1.3'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
+        version: ['1.3', '1.4', '1.5', 'nightly']
+        os: [ubuntu-latest]
 
     steps:
       - name: Checkout InvertibleNetworks.jl
@@ -26,7 +22,6 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
 
       - name: Build InvertibleNetworks.jl
         uses: julia-actions/julia-buildpkg@latest

--- a/.github/workflows/.runtests.yml
+++ b/.github/workflows/.runtests.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches-ignore:
+      - 'gpu'
 
 jobs:
   test:
@@ -33,7 +36,7 @@ jobs:
 
       - name: Run tests
         uses: julia-actions/julia-runtest@latest
-    
+
       - name: Run simple example
         if: runner.os == 'linux'
         run: julia --project examples/layers/layer_actnorm.jl

--- a/src/InvertibleNetworks.jl
+++ b/src/InvertibleNetworks.jl
@@ -7,6 +7,9 @@ module InvertibleNetworks
 import Base.size, Base.getindex, Flux.glorot_uniform, Base.reverse, Base.reverse!
 using LinearAlgebra, Random, NNlib, Flux, Statistics, Wavelets, Zygote
 
+# For function signatur definition
+import CUDA: CuArray
+
 export clear_grad!, glorot_uniform, get_params
 
 

--- a/src/conditional_layers/conditional_layer_residual_block.jl
+++ b/src/conditional_layers/conditional_layer_residual_block.jl
@@ -7,19 +7,19 @@ export ConditionalResidualBlock
 """
     RB = ConditionalResidualBlock(nx1, nx2, nx_in, ny1, ny2, ny_in, n_hidden, batchsize; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1)
 
- Create a (non-invertible) conditional residual block, consisting of one dense and three convolutional layers 
+ Create a (non-invertible) conditional residual block, consisting of one dense and three convolutional layers
  with ReLU activation functions. The dense operator maps the data to the image space and both tensors are
  concatenated and fed to the subsequent convolutional layers.
 
- *Input*: 
+ *Input*:
 
  - `nx1`, `nx2`, `nx_in`: spatial dimensions and no. of channels of input image
 
  - `ny1`, `ny2`, `ny_in`: spatial dimensions and no. of channels of input data
- 
+
  - `n_hidden`: number of hidden channels
 
- - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third 
+ - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third
     operator, `k2` is the kernel size of the second operator.
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
@@ -29,7 +29,7 @@ export ConditionalResidualBlock
 or
 
  *Output*:
- 
+
  - `RB`: conditional residual block layer
 
  *Usage:*
@@ -74,11 +74,11 @@ function ConditionalResidualBlock(nx1, nx2, nx_in, ny1, ny2, ny_in, n_hidden, ba
     b2 = Parameter(zeros(Float32, n_hidden))
 
     # Dimensions for convolutions
-    cdims1 = DenseConvDims((nx1, nx2, 2*nx_in, batchsize), (k1, k1, 2*nx_in, n_hidden); 
+    cdims1 = DenseConvDims((nx1, nx2, 2*nx_in, batchsize), (k1, k1, 2*nx_in, n_hidden);
         stride=(s1,s1), padding=(p1,p1))
-    cdims2 = DenseConvDims((Int(nx1/s1), Int(nx2/s1), n_hidden, batchsize), 
+    cdims2 = DenseConvDims((Int(nx1/s1), Int(nx2/s1), n_hidden, batchsize),
         (k2, k2, n_hidden, n_hidden); stride=(s2,s2), padding=(p2,p2))
-    cdims3 = DenseConvDims((nx1, nx2, nx_in, batchsize), (k1, k1, nx_in, n_hidden); 
+    cdims3 = DenseConvDims((nx1, nx2, nx_in, batchsize), (k1, k1, nx_in, n_hidden);
         stride=(s1,s1), padding=(p1,p1))
 
     return ConditionalResidualBlock(W0, W1, W2, W3, b0, b1, b2, cdims1, cdims2, cdims3)
@@ -88,7 +88,7 @@ function forward(X0, D, RB::ConditionalResidualBlock; save=false)
 
     # Dimensions of input image X
     nx1, nx2, nx_in, batchsize = size(X0)
-    
+
     Y0 = RB.W0.data*reshape(D, :, batchsize) .+ RB.b0.data
     X0_ = ReLU(reshape(Y0, nx1, nx2, nx_in, batchsize))
     X1 = tensor_cat(X0, X0_)
@@ -98,7 +98,7 @@ function forward(X0, D, RB::ConditionalResidualBlock; save=false)
 
     Y2 = X2 + conv(X2, RB.W2.data, RB.cdims2) .+ reshape(RB.b2.data, 1, 1, :, 1)
     X3 = ReLU(Y2)
-    
+
     Y3 = ∇conv_data(X3, RB.W3.data, RB.cdims3)
     X4 = ReLU(Y3)
 
@@ -124,19 +124,19 @@ function backward(ΔX4, ΔD, X0, D, RB::ConditionalResidualBlock)
     ΔY2 = ReLUgrad(ΔX3, Y2)
     ΔX2 = ∇conv_data(ΔY2, RB.W2.data, RB.cdims2) + ΔY2
     ΔW2 = ∇conv_filter(X2, ΔY2, RB.cdims2)
-    Δb2 = sum(ΔY2, dims=(1,2,4))[1,1,:,1]
+    Δb2 = sum(ΔY2, dims=[1,2,4])[1,1,:,1]
 
     ΔY1 = ReLUgrad(ΔX2, Y1)
     ΔX1 = ∇conv_data(ΔY1, RB.W1.data, RB.cdims1)
     ΔW1 = ∇conv_filter(X1, ΔY1, RB.cdims1)
-    Δb1 = sum(ΔY1, dims=(1,2,4))[1,1,:,1]
+    Δb1 = sum(ΔY1, dims=[1,2,4])[1,1,:,1]
 
     ΔX0, ΔX0_ = tensor_split(ΔX1)
     ΔY0 = ReLUgrad(ΔX0_, reshape(Y0, nx1, nx2, nx_in, batchsize))
     ΔD += reshape(transpose(RB.W0.data)*reshape(ΔY0, :, batchsize), size(D))
     ΔW0 = reshape(ΔY0, :, batchsize)*transpose(reshape(D, :, batchsize))
     Δb0 = vec(sum(ΔY0, dims=4))
-    
+
     # Set gradients
     RB.W0.grad = ΔW0
     RB.W1.grad = ΔW1

--- a/src/layers/invertible_layer_actnorm.jl
+++ b/src/layers/invertible_layer_actnorm.jl
@@ -64,8 +64,8 @@ function forward(X::AbstractArray{Float32, 4}, AN::ActNorm; logdet=nothing)
     # Initialize during first pass such that
     # output has zero mean and unit variance
     if AN.s.data == nothing && AN.is_reversed == false
-        μ = mean(X; dims=(1, 2, 4))[1, 1, :, 1]
-        σ_sqr = var(X; dims=(1, 2, 4))[1, 1, :, 1]
+        μ = mean(X; dims=[1, 2, 4])[1, 1, :, 1]
+        σ_sqr = var(X; dims=[1, 2, 4])[1, 1, :, 1]
         AN.s.data = 1f0 ./ sqrt.(σ_sqr)
         AN.b.data = -μ ./ sqrt.(σ_sqr)
     end
@@ -83,8 +83,8 @@ function forward(X::AbstractArray{Float32, 5}, AN::ActNorm; logdet=nothing)
     # Initialize during first pass such that
     # output has zero mean and unit variance
     if AN.s.data == nothing && AN.is_reversed == false
-        μ = mean(X; dims=(1, 2, 3, 5))[1, 1, 1, :, 1]
-        σ_sqr = var(X; dims=(1, 2, 3, 5))[1, 1, 1, :, 1]
+        μ = mean(X; dims=[1, 2, 3, 5])[1, 1, 1, :, 1]
+        σ_sqr = var(X; dims=[1, 2, 3, 5])[1, 1, 1, :, 1]
         AN.s.data = 1f0 ./ sqrt.(σ_sqr)
         AN.b.data = -μ ./ sqrt.(σ_sqr)
     end
@@ -102,8 +102,8 @@ function inverse(Y::AbstractArray{Float32, 4}, AN::ActNorm; logdet=nothing)
     # Initialize during first pass such that
     # output has zero mean and unit variance
     if AN.s.data == nothing && AN.is_reversed == true
-        μ = mean(Y; dims=(1,2,4))[1,1,:,1]
-        σ_sqr = var(Y; dims=(1,2,4))[1,1,:,1]
+        μ = mean(Y; dims=[1,2,4])[1,1,:,1]
+        σ_sqr = var(Y; dims=[1,2,4])[1,1,:,1]
         AN.s.data = sqrt.(σ_sqr)
         AN.b.data = μ
     end
@@ -121,8 +121,8 @@ function inverse(Y::AbstractArray{Float32, 5}, AN::ActNorm; logdet=nothing)
     # Initialize during first pass such that
     # output has zero mean and unit variance
     if AN.s.data == nothing && AN.is_reversed == true
-        μ = mean(Y; dims=(1,2,3,5))[1,1,1,:,1]
-        σ_sqr = var(Y; dims=(1,2,3,5))[1,1,1,:,1]
+        μ = mean(Y; dims=[1,2,3,5])[1,1,1,:,1]
+        σ_sqr = var(Y; dims=[1,2,3,5])[1,1,1,:,1]
         AN.s.data = sqrt.(σ_sqr)
         AN.b.data = μ
     end
@@ -137,9 +137,9 @@ function backward(ΔY::AbstractArray{Float32, 4}, Y::AbstractArray{Float32, 4}, 
     nx, ny, n_in, batchsize = size(Y)
     X = inverse(Y, AN; logdet=false)
     ΔX = ΔY .* reshape(AN.s.data, 1, 1, :, 1)
-    Δs = sum(ΔY .* X, dims=(1, 2, 4))[1, 1, :, 1]
+    Δs = sum(ΔY .* X, dims=[1, 2, 4])[1, 1, :, 1]
     AN.logdet == true && (Δs -= logdet_backward(nx, ny, AN.s))
-    Δb = sum(ΔY, dims=(1, 2, 4))[1, 1, :, 1]
+    Δb = sum(ΔY, dims=[1, 2, 4])[1, 1, :, 1]
     AN.s.grad = Δs
     AN.b.grad = Δb
     return ΔX, X
@@ -150,9 +150,9 @@ function backward(ΔY::AbstractArray{Float32, 5}, Y::AbstractArray{Float32, 5}, 
     nx, ny, nz, n_in, batchsize = size(Y)
     X = inverse(Y, AN; logdet=false)
     ΔX = ΔY .* reshape(AN.s.data, 1, 1, 1, :, 1)
-    Δs = sum(ΔY .* X, dims=(1, 2, 3, 5))[1, 1, 1, :, 1]
+    Δs = sum(ΔY .* X, dims=[1, 2, 3, 5])[1, 1, 1, :, 1]
     AN.logdet == true && (Δs -= logdet_backward(nx, ny, nz, AN.s))
-    Δb = sum(ΔY, dims=(1, 2, 3, 5))[1, 1, 1, :, 1]
+    Δb = sum(ΔY, dims=[1, 2, 3, 5])[1, 1, 1, :, 1]
     AN.s.grad = Δs
     AN.b.grad = Δb
     return ΔX, X
@@ -163,9 +163,9 @@ function backward_inv(ΔX::AbstractArray{Float32, 4}, X::AbstractArray{Float32, 
     nx, ny, n_in, batchsize = size(X)
     Y = forward(X, AN; logdet=false)
     ΔY = ΔX ./ reshape(AN.s.data, 1, 1, :, 1)
-    Δs = -sum(ΔX .* X ./ reshape(AN.s.data, 1, 1, :, 1), dims=(1, 2, 4))[1, 1, :, 1]
+    Δs = -sum(ΔX .* X ./ reshape(AN.s.data, 1, 1, :, 1), dims=[1, 2, 4])[1, 1, :, 1]
     AN.logdet == true && (Δs += logdet_backward(nx, ny, AN.s))
-    Δb = -sum(ΔX ./ reshape(AN.s.data, 1, 1, :, 1), dims=(1, 2, 4))[1, 1, :, 1]
+    Δb = -sum(ΔX ./ reshape(AN.s.data, 1, 1, :, 1), dims=[1, 2, 4])[1, 1, :, 1]
     AN.s.grad = Δs
     AN.b.grad = Δb
     return ΔY, Y
@@ -176,9 +176,9 @@ function backward_inv(ΔX::AbstractArray{Float32, 5}, X::AbstractArray{Float32, 
     nx, ny, nz, n_in, batchsize = size(X)
     Y = forward(X, AN; logdet=false)
     ΔY = ΔX ./ reshape(AN.s.data, 1, 1, 1, :, 1)
-    Δs = -sum(ΔX .* X ./ reshape(AN.s.data, 1, 1, 1, :, 1), dims=(1, 2, 3, 5))[1, 1, 1, :, 1]
+    Δs = -sum(ΔX .* X ./ reshape(AN.s.data, 1, 1, 1, :, 1), dims=[1, 2, 3, 5])[1, 1, 1, :, 1]
     AN.logdet == true && (Δs += logdet_backward(nx, ny, AN.s))
-    Δb = -sum(ΔX ./ reshape(AN.s.data, 1, 1, 1, :, 1), dims=(1, 2, 3, 5))[1, 1, 1, :, 1]
+    Δb = -sum(ΔX ./ reshape(AN.s.data, 1, 1, 1, :, 1), dims=[1, 2, 3, 5])[1, 1, 1, :, 1]
     AN.s.grad = Δs
     AN.b.grad = Δb
     return ΔY, Y

--- a/src/layers/invertible_layer_basic.jl
+++ b/src/layers/invertible_layer_basic.jl
@@ -93,7 +93,7 @@ end
 # 2D Forward pass: Input X, Output Y
 function forward(X1::AbstractArray{Float32, 4}, X2::AbstractArray{Float32, 4}, L::CouplingLayerBasic; save::Bool=false, logdet=nothing)
     isnothing(logdet) ? logdet = (L.logdet && ~L.is_reversed) : logdet = logdet
-    
+
     # Coupling layer
     k = size(X1, 3)
     Y1 = copy(X1)
@@ -112,7 +112,7 @@ end
 # 3D Forward pass: Input X, Output Y
 function forward(X1::AbstractArray{Float32, 5}, X2::AbstractArray{Float32, 5}, L::CouplingLayerBasic; save::Bool=false, logdet=nothing)
     isnothing(logdet) ? logdet = (L.logdet && ~L.is_reversed) : logdet = logdet
-    
+
     # Coupling layer
     k = size(X1, 4)
     Y1 = copy(X1)
@@ -138,7 +138,7 @@ function inverse(Y1::AbstractArray{Float32, 4}, Y2::AbstractArray{Float32, 4}, L
     logS_T = L.RB.forward(X1)
     S = Sigmoid(logS_T[:, :, 1:k, :])
     T = logS_T[:, :, k+1:end, :]
-    X2 = (Y2 - T) ./ (S + randn(Float32, size(S))*eps(1f0)) # add epsilon to avoid division by 0
+    X2 = (Y2 - T) ./ (S .+ eps(1f0)) # add epsilon to avoid division by 0
 
     if logdet
         save == true ? (return X1, X2, -coupling_logdet_forward(S), S) : (return X1, X2, -coupling_logdet_forward(S))
@@ -157,7 +157,7 @@ function inverse(Y1::AbstractArray{Float32, 5}, Y2::AbstractArray{Float32, 5}, L
     logS_T = L.RB.forward(X1)
     S = Sigmoid(logS_T[:, :, :, 1:k, :])
     T = logS_T[:, :, :, k+1:end, :]
-    X2 = (Y2 - T) ./ (S + randn(Float32, size(S))*eps(1f0)) # add epsilon to avoid division by 0
+    X2 = (Y2 - T) ./ (S .+ eps(1f0)) # add epsilon to avoid division by 0
 
     if logdet
         save == true ? (return X1, X2, -coupling_logdet_forward(S), S) : (return X1, X2, -coupling_logdet_forward(S))

--- a/src/layers/invertible_layer_conv1x1.jl
+++ b/src/layers/invertible_layer_conv1x1.jl
@@ -107,8 +107,11 @@ end
 
 function mat_tens_i(out::AbstractArray{Float32, 3}, Mat::AbstractArray{Float32, 2},
                     Tens::AbstractArray{Float32, 3}, Mat2::AbstractArray{Float32, 2})
+    tmp = cuzeros(out, size(out, 2), size(out, 3))
     for i=1:size(out, 1)
-        @views broadcast!(*, out[i, :, :], Mat*Tens[i, :, :], Mat2)
+        mul!(tmp, Mat, Tens[i, :, :])
+        broadcast!(*, tmp, tmp, Mat2)
+        @views copyto!(out[i, :, :], tmp)
     end
     return out
 end

--- a/src/layers/invertible_layer_conv1x1.jl
+++ b/src/layers/invertible_layer_conv1x1.jl
@@ -109,7 +109,7 @@ function mat_tens_i(out::AbstractArray{Float32, 3}, Mat::AbstractArray{Float32, 
                     Tens::AbstractArray{Float32, 3}, Mat2::AbstractArray{Float32, 2})
     for i=1:size(out, 1)
         mul!(view(out, i, :, :), Mat, Tens[i, :, :])
-        broadcast!(*, out[i, :, :], out[i, :, :], Mat2)
+        @views broadcast!(*, out[i, :, :], out[i, :, :], Mat2)
     end
     return out
 end
@@ -150,14 +150,14 @@ function conv1x1_grad_v(X::AbstractArray{Float32, N}, ΔY::AbstractArray{Float32
     tmp = cuzeros(X, k, k)
     for i=1:k
         # ∂V1
-        mul!(tmp, view(∂V1, i, :, :), M1)
+        mul!(tmp, ∂V1[i, :, :], M1)
         @views adjoint ? adjoint!(∂V1[i, :, :], tmp) : copyto!(∂V1[i, :, :], tmp)
         # ∂V2
-        v2 = view(∂V2, i, :, :)
+        v2 = ∂V2[i, :, :]
         broadcast!(+, tmp, v2, 4f0 * V1 * v2 * V3 - 2f0 * (V1 * v2 + v2 * V3))
         @views adjoint ? adjoint!(∂V2[i, :, :], tmp) : copyto!(∂V2[i, :, :], tmp)
         # ∂V3
-        mul!(tmp, M3, view(∂V3, i, :, :))
+        mul!(tmp, M3, ∂V3[i, :, :])
         @views adjoint ? adjoint!(∂V3[i, :, :], tmp) : copyto!(∂V3[i, :, :], tmp)
     end
 

--- a/src/layers/invertible_layer_conv1x1.jl
+++ b/src/layers/invertible_layer_conv1x1.jl
@@ -65,15 +65,25 @@ function Conv1x1(v1, v2, v3; logdet=false)
     return Conv1x1(k, v1, v2, v3, logdet)
 end
 
-
-function partial_derivative_outer(v, j)
+function partial_derivative_outer(v::AbstractArray{Float32, 1})
     k = length(v)
-    dV = cuzeros(v, k, k)
-    dV[:, j] = v
-    dV[j, :] += v
-    return (dV*(v'*v) - 2f0*v*v'*v[j])/(v'*v)^2
+    out1 = v * v'
+    n = v' * v
+    outer = cuzeros(v, k, k, k)
+    for i=1:k
+        copyto!(view(outer, i, :, :), out1)
+    end
+    broadcast!(*, outer, v, outer)
+    broadcast!(*, outer, -2f0/n, outer)
+    for j=1:k
+        v1 = view(outer,j, :, j)
+        broadcast!(+, v1, v1, v)
+        v1 = view(outer,j, j, :)
+        broadcast!(+, v1, v1, v)
+    end
+    broadcast!(*, outer, 1/n, outer)
+    return outer
 end
-
 
 function conv1x1_grad_v(X::AbstractArray{Float32, 4}, ΔY::AbstractArray{Float32, 4}, C::Conv1x1; adjoint=false)
 
@@ -84,7 +94,7 @@ function conv1x1_grad_v(X::AbstractArray{Float32, 4}, ΔY::AbstractArray{Float32
     v2 = C.v2.data
     v3 = C.v3.data
     k = length(v1)
-    
+
     dv1 = cuzeros(X, k)
     dv2 = cuzeros(X, k)
     dv3 = cuzeros(X, k)
@@ -98,23 +108,23 @@ function conv1x1_grad_v(X::AbstractArray{Float32, 4}, ΔY::AbstractArray{Float32
         Xi = reshape(X[:,:,:,i], :, n_in)
         ΔYi = reshape(ΔY[:,:,:,i], :, n_in)
 
+        dV1 =partial_derivative_outer(v1)
+        dV2 =partial_derivative_outer(v2)
+        dV3 =partial_derivative_outer(v3)
+
         for j=1:k
 
-            dV1 = partial_derivative_outer(v1, j)
-            dV2 = partial_derivative_outer(v2, j)
-            dV3 = partial_derivative_outer(v3, j)
-
-            ∂V1 = dV1 - 2f0*dV1*V2 - 2f0*dV1*V3 + 4f0*dV1*V2*V3
-            ∂V2 = dV2 - 2f0*V1*dV2 - 2f0*dV2*V3 + 4f0*V1*dV2*V3
-            ∂V3 = dV3 - 2f0*V1*dV3 - 2f0*V2*dV3 + 4f0*V1*V2*dV3
+            ∂V1 = dV1[j, :, :] - 2f0*dV1[j, :, :]*V2 - 2f0*dV1[j, :, :]*V3 + 4f0*dV1[j, :, :]*V2*V3
+            ∂V2 = dV2[j, :, :] - 2f0*V1*dV2[j, :, :] - 2f0*dV2[j, :, :]*V3 + 4f0*V1*dV2[j, :, :]*V3
+            ∂V3 = dV3[j, :, :] - 2f0*V1*dV3[j, :, :] - 2f0*V2*dV3[j, :, :] + 4f0*V1*V2*dV3[j, :, :]
 
             if ~adjoint
                 dv1[j] += sum(vec((-2f0*Xi*∂V1).*ΔYi)')
-                dv2[j] += sum(vec((-2f0*Xi*∂V2).*ΔYi)')   
+                dv2[j] += sum(vec((-2f0*Xi*∂V2).*ΔYi)')
                 dv3[j] += sum(vec((-2f0*Xi*∂V3).*ΔYi)')
             else
                 dv1[j] += sum(vec((-2f0*Xi*∂V1').*ΔYi)')
-                dv2[j] += sum(vec((-2f0*Xi*∂V2').*ΔYi)')   
+                dv2[j] += sum(vec((-2f0*Xi*∂V2').*ΔYi)')
                 dv3[j] += sum(vec((-2f0*Xi*∂V3').*ΔYi)')
             end
 
@@ -146,23 +156,24 @@ function conv1x1_grad_v(X::AbstractArray{Float32, 5}, ΔY::AbstractArray{Float32
         Xi = reshape(X[:,:,:,:,i], :, n_in)
         ΔYi = reshape(ΔY[:,:,:,:,i], :, n_in)
 
+        dV1 =partial_derivative_outer(v1)
+        dV2 =partial_derivative_outer(v2)
+        dV3 =partial_derivative_outer(v3)
+
         for j=1:k
 
-            dV1 = partial_derivative_outer(v1, j)
-            dV2 = partial_derivative_outer(v2, j)
-            dV3 = partial_derivative_outer(v3, j)
+            ∂V1 = dV1[j, :, :] - 2f0*dV1[j, :, :]*V2 - 2f0*dV1[j, :, :]*V3 + 4f0*dV1[j, :, :]*V2*V3
+            ∂V2 = dV2[j, :, :] - 2f0*V1*dV2[j, :, :] - 2f0*dV2[j, :, :]*V3 + 4f0*V1*dV2[j, :, :]*V3
+            ∂V3 = dV3[j, :, :] - 2f0*V1*dV3[j, :, :] - 2f0*V2*dV3[j, :, :] + 4f0*V1*V2*dV3[j, :, :]
 
-            ∂V1 = dV1 - 2f0*dV1*V2 - 2f0*dV1*V3 + 4f0*dV1*V2*V3
-            ∂V2 = dV2 - 2f0*V1*dV2 - 2f0*dV2*V3 + 4f0*V1*dV2*V3
-            ∂V3 = dV3 - 2f0*V1*dV3 - 2f0*V2*dV3 + 4f0*V1*V2*dV3
 
             if ~adjoint
                 dv1[j] += sum(vec((-2f0*Xi*∂V1).*ΔYi)')
-                dv2[j] += sum(vec((-2f0*Xi*∂V2).*ΔYi)')   
+                dv2[j] += sum(vec((-2f0*Xi*∂V2).*ΔYi)')
                 dv3[j] += sum(vec((-2f0*Xi*∂V3).*ΔYi)')
             else
                 dv1[j] += sum(vec((-2f0*Xi*∂V1').*ΔYi)')
-                dv2[j] += sum(vec((-2f0*Xi*∂V2').*ΔYi)')   
+                dv2[j] += sum(vec((-2f0*Xi*∂V2').*ΔYi)')
                 dv3[j] += sum(vec((-2f0*Xi*∂V3').*ΔYi)')
             end
 
@@ -176,7 +187,7 @@ function forward(X::AbstractArray{Float32, 4}, C::Conv1x1; logdet=nothing)
     isnothing(logdet) ? logdet = C.logdet : logdet = logdet
     nx, ny, n_in, batchsize = size(X)
     Y = cuzeros(X, nx, ny, n_in, batchsize)
-    
+
     v1 = C.v1.data
     v2 = C.v2.data
     v3 = C.v3.data
@@ -209,7 +220,7 @@ end
 
 # Forward pass and update weights
 function forward(X_tuple::Tuple, C::Conv1x1)
-    ΔX = X_tuple[1] 
+    ΔX = X_tuple[1]
     X = X_tuple[2]
     ΔY = forward(ΔX, C; logdet=false)    # forward propagate residual
     Y = forward(X, C; logdet=false)  # recompute forward state

--- a/src/layers/invertible_layer_conv1x1.jl
+++ b/src/layers/invertible_layer_conv1x1.jl
@@ -108,8 +108,7 @@ end
 function mat_tens_i(out::AbstractArray{Float32, 3}, Mat::AbstractArray{Float32, 2},
                     Tens::AbstractArray{Float32, 3}, Mat2::AbstractArray{Float32, 2})
     for i=1:size(out, 1)
-        mul!(view(out, i, :, :), Mat, Tens[i, :, :])
-        @views broadcast!(*, out[i, :, :], out[i, :, :], Mat2)
+        @views broadcast!(*, out[i, :, :], Mat*Tens[i, :, :], Mat2)
     end
     return out
 end

--- a/src/layers/invertible_layer_glow.jl
+++ b/src/layers/invertible_layer_glow.jl
@@ -13,12 +13,12 @@ or
 
     CL = CouplingLayerGlow(nx, ny, n_in, n_hidden, batchsize; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1, logdet=false)
 
- Create a Real NVP-style invertible coupling layer based on 1x1 convolutions and a residual block. 
+ Create a Real NVP-style invertible coupling layer based on 1x1 convolutions and a residual block.
 
- *Input*: 
- 
+ *Input*:
+
  - `C::Conv1x1`: 1x1 convolution layer
- 
+
  - `RB::ResidualBlock`: residual block layer consisting of 3 convolutional layers with ReLU activations.
 
  - `logdet`: bool to indicate whether to compte the logdet of the layer
@@ -26,10 +26,10 @@ or
  or
 
  - `nx, ny`: spatial dimensions of input
- 
+
  - `n_in`, `n_hidden`: number of input and hidden channels
 
- - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third 
+ - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third
     operator, `k2` is the kernel size of the second operator.
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
@@ -37,7 +37,7 @@ or
  - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
 
  *Output*:
- 
+
  - `CL`: Invertible Real NVP coupling layer.
 
  *Usage:*
@@ -88,7 +88,7 @@ function forward(X::AbstractArray{Float32, 4}, L::CouplingLayerGlow)
 
     # Get dimensions
     k = Int(L.C.k/2)
-    
+
     X_ = L.C.forward(X)
     X1, X2 = tensor_split(X_)
 
@@ -98,7 +98,7 @@ function forward(X::AbstractArray{Float32, 4}, L::CouplingLayerGlow)
     T = logS_T[:, :, k+1:end, :]
     Y1 = S.*X1 + T
     Y = tensor_cat(Y1, Y2)
-    
+
     L.logdet == true ? (return Y, glow_logdet_forward(S)) : (return Y)
 end
 
@@ -113,7 +113,7 @@ function inverse(Y::AbstractArray{Float32, 4}, L::CouplingLayerGlow; save=false)
     logS_T = L.RB.forward(X2)
     S = Sigmoid(logS_T[:,:,1:k,:])
     T = logS_T[:, :, k+1:end, :]
-    X1 = (Y1 - T) ./ (S + randn(Float32, size(S))*eps(1f0)) # add epsilon to avoid division by 0
+    X1 = (Y1 - T) ./ (S .+ eps(1f0)) # add epsilon to avoid division by 0
     X_ = tensor_cat(X1, X2)
     X = L.C.inverse(X_)
 

--- a/src/layers/invertible_layer_hyperbolic.jl
+++ b/src/layers/invertible_layer_hyperbolic.jl
@@ -7,13 +7,13 @@ export HyperbolicLayer
 """
     HyperbolicLayer(nx, ny, n_in, batchsize, kernel, stride, pad; action="same", α=1f0, hidden_factor=1)
 
-or 
+or
 
     HyperbolicLayer(W, b, nx, ny, batchsize, stride, pad; action="same", α=1f0)
 
 Create an invertible hyperbolic coupling layer.
 
-*Input*: 
+*Input*:
 
  - `nx`, `ny`, `n_in`, `batchsize`: Dimensions of input tensor
 
@@ -31,7 +31,7 @@ Create an invertible hyperbolic coupling layer.
     After applying the transpose convolution, the dimensions are back to the input dimensions.
 
 *Output*:
- 
+
  - `HL`: Invertible hyperbolic coupling layer
 
  *Usage:*
@@ -61,7 +61,7 @@ end
 @Flux.functor HyperbolicLayer
 
 # Constructor
-function HyperbolicLayer(nx::Int64, ny::Int64, n_in::Int64, batchsize::Int64, kernel::Int64, 
+function HyperbolicLayer(nx::Int64, ny::Int64, n_in::Int64, batchsize::Int64, kernel::Int64,
     stride::Int64, pad::Int64; action="same", α=1f0, hidden_factor=1)
 
     # Set ouput/hidden dimensions
@@ -81,14 +81,14 @@ function HyperbolicLayer(nx::Int64, ny::Int64, n_in::Int64, batchsize::Int64, ke
     W = Parameter(glorot_uniform(kernel, kernel, n_out, n_hidden))
     b = Parameter(zeros(Float32, n_hidden))
 
-    cdims = DenseConvDims((nx, ny, n_out, batchsize), (kernel, kernel, n_out, n_hidden); 
+    cdims = DenseConvDims((nx, ny, n_out, batchsize), (kernel, kernel, n_out, n_hidden);
         stride=(stride, stride), padding=(pad, pad))
 
     return HyperbolicLayer(W, b, α, cdims, action)
 end
 
 # Constructor for given weights
-function HyperbolicLayer(W::AbstractArray{Float32, 4}, b::AbstractArray{Float32, 1}, nx::Int64, ny::Int64, 
+function HyperbolicLayer(W::AbstractArray{Float32, 4}, b::AbstractArray{Float32, 1}, nx::Int64, ny::Int64,
     batchsize::Int64, stride::Int64, pad::Int64; action="same", α=1f0)
 
     kernel, n_in, n_hidden = size(W)[2:4]
@@ -109,7 +109,7 @@ function HyperbolicLayer(W::AbstractArray{Float32, 4}, b::AbstractArray{Float32,
     W = Parameter(W)
     b = Parameter(b)
 
-    cdims = DenseConvDims((nx, ny, n_out, batchsize), (kernel, kernel, n_out, n_hidden); 
+    cdims = DenseConvDims((nx, ny, n_out, batchsize), (kernel, kernel, n_out, n_hidden);
         stride=(stride, stride), padding=(pad, pad))
 
     return HyperbolicLayer(W, b, α, cdims, action)
@@ -185,11 +185,11 @@ function backward(ΔX_curr, ΔX_new, X_curr, X_new, HL::HyperbolicLayer)
     ΔX_convT = copy(ΔX_new)
     ΔX_relu = -HL.α*conv(ΔX_convT, HL.W.data, HL.cdims)
     ΔW = -HL.α*∇conv_filter(ΔX_convT, X_relu, HL.cdims)
-    
+
     ΔX_conv = ReLUgrad(ΔX_relu, X_conv)
     ΔX_curr += ∇conv_data(ΔX_conv, HL.W.data, HL.cdims)
     ΔW += ∇conv_filter(X_curr, ΔX_conv, HL.cdims)
-    Δb = sum(ΔX_conv; dims=(1,2,4))[1,1,:,1]
+    Δb = sum(ΔX_conv; dims=[1,2,4])[1,1,:,1]
 
     ΔX_curr += 2f0*ΔX_new
     ΔX_prev = -ΔX_new

--- a/src/layers/invertible_layer_slim_affine.jl
+++ b/src/layers/invertible_layer_slim_affine.jl
@@ -11,10 +11,10 @@ export AffineCouplingLayerSLIM
 
  Create an invertible affine SLIM coupling layer.
 
- *Input*: 
+ *Input*:
 
  - `nx, ny`: spatial dimensions of input
- 
+
  - `n_in`, `n_hidden`: number of input and hidden channels
 
  - `Ψ`: link function
@@ -23,7 +23,7 @@ export AffineCouplingLayerSLIM
 
  - `permute`: bool to indicate whether to apply a channel permutation (default is `false`)
 
- - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third 
+ - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third
     operator, `k2` is the kernel size of the second operator
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
@@ -31,7 +31,7 @@ export AffineCouplingLayerSLIM
  - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
 
  *Output*:
- 
+
  - `CS`: Invertible SLIM coupling layer
 
  *Usage:*
@@ -63,7 +63,7 @@ end
 @Flux.functor AffineCouplingLayerSLIM
 
 # Constructor from input dimensions
-function AffineCouplingLayerSLIM(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64, Ψ::Function; 
+function AffineCouplingLayerSLIM(nx::Int64, ny::Int64, n_in::Int64, n_hidden::Int64, batchsize::Int64, Ψ::Function;
     k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, logdet::Bool=false, permute::Bool=false)
 
     # 1x1 Convolution and residual block for invertible layer
@@ -79,7 +79,7 @@ function forward(X::AbstractArray{Float32, 4}, D, J, CS::AffineCouplingLayerSLIM
 
     # Get dimensions
     nx, ny, n_s, batchsize = size(X)
-    
+
     # Permute and split
     isnothing(CS.C) ? (X_ = copy(X)) : (X_ = CS.C.forward(X))
     X1_, X2_ = tensor_split(X_)
@@ -121,7 +121,7 @@ function inverse(Y::AbstractArray{Float32, 4}, D, J, CS::AffineCouplingLayerSLIM
     logS_T = CS.RB.forward(gs)
     logS, T = tensor_split(logS_T)
     S = Sigmoid(logS)
-    X2_ = (Y2_ - T) ./ (S + randn(Float32, size(S))*eps(1f0)) # add epsilon to avoid 
+    X2_ = (Y2_ - T) ./ (S .+ eps(1f0)) # add epsilon to avoid
     X_ = tensor_cat(X1_, X2_)
 
     isnothing(CS.C) ? (X = copy(X_)) : (X = CS.C.inverse(X_))

--- a/src/layers/layer_affine.jl
+++ b/src/layers/layer_affine.jl
@@ -10,14 +10,14 @@ export AffineLayer
 
  Create a layer for an affine transformation.
 
- *Input*: 
- 
- - `nx`, `ny, `nc`: input dimensions and number of channels 
- 
+ *Input*:
+
+ - `nx`, `ny, `nc`: input dimensions and number of channels
+
  - `logdet`: bool to indicate whether to compute the logdet
 
  *Output*:
- 
+
  - `AL`: Network layer for affine transformation.
 
  *Usage:*
@@ -55,14 +55,14 @@ end
 function forward(X, AL::AffineLayer)
 
     Y = X .* AL.s.data .+ AL.b.data
-    
+
     # If logdet true, return as second ouput argument
     AL.logdet == true ? (return Y, logdet_forward(AL.s)) : (return Y)
 end
 
 # Inverse pass: Input Y, Output X
 function inverse(Y, AL::AffineLayer)
-    X = (Y .- AL.b.data) ./ (AL.s.data + randn(Float32, size(AL.s.data)) .* eps(1f0))   # avoid division by 0
+    X = (Y .- AL.b.data) ./ (AL.s.data .+ eps(1f0))   # avoid division by 0
     return X
 end
 
@@ -89,5 +89,5 @@ end
 get_params(AL::AffineLayer) = [AL.s, AL.b]
 
 # Logdet
-logdet_forward(s) = sum(log.(abs.(s.data))) 
+logdet_forward(s) = sum(log.(abs.(s.data)))
 logdet_backward(s) = 1f0 ./ s.data

--- a/src/layers/layer_affine.jl
+++ b/src/layers/layer_affine.jl
@@ -46,7 +46,7 @@ end
 
 # Constructor: Initialize with nothing
 function AffineLayer(nx::Int64, ny::Int64, nc::Int64; logdet=false)
-    s = Parameter(glorot_uniform(nx, ny, nc))
+    s = Parameter(ones(Float32, nx, ny, nc))
     b = Parameter(zeros(Float32, nx, ny, nc))
     return AffineLayer(s, b, logdet)
 end
@@ -62,7 +62,7 @@ end
 
 # Inverse pass: Input Y, Output X
 function inverse(Y, AL::AffineLayer)
-    X = (Y .- AL.b.data) ./ (AL.s.data .+ eps(1f0))   # avoid division by 0
+    X = (Y .- AL.b.data) ./ (AL.s.data)   # avoid division by 0
     return X
 end
 

--- a/src/layers/layer_residual_block.jl
+++ b/src/layers/layer_residual_block.jl
@@ -20,13 +20,13 @@ or
  convolution is the corresponding transpose operation and upsamples the data to either its original dimensions
  or to twice the number of input channels (for `fan=true`). The first and second layer contain a bias term.
 
- *Input*: 
+ *Input*:
 
  - `nx`, `ny`, `nz`: spatial dimensions of input
- 
+
  - `n_in`, `n_hidden`: number of input and hidden channels
 
- - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third 
+ - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third
     operator, `k2` is the kernel size of the second operator.
 
  - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
@@ -47,7 +47,7 @@ or
  - `nx`, `ny`: spatial dimensions of input image
 
  *Output*:
- 
+
  - `RB`: residual block layer
 
  *Usage:*
@@ -92,11 +92,11 @@ function ResidualBlock(nx, ny, n_in, n_hidden, batchsize; k1=3, k2=3, p1=1, p2=1
     b2 = Parameter(zeros(Float32, n_hidden))
 
     # Dimensions for convolutions
-    cdims1 = DenseConvDims((nx, ny, n_in, batchsize), (k1, k1, n_in, n_hidden); 
+    cdims1 = DenseConvDims((nx, ny, n_in, batchsize), (k1, k1, n_in, n_hidden);
         stride=(s1, s1), padding=(p1, p1))
-    cdims2 = DenseConvDims((Int(nx/s1), Int(ny/s1), n_hidden, batchsize), 
+    cdims2 = DenseConvDims((Int(nx/s1), Int(ny/s1), n_hidden, batchsize),
         (k2, k2, n_hidden, n_hidden); stride=(s2, s2), padding=(p2, p2))
-    cdims3 = DenseConvDims((nx, ny, 2*n_in, batchsize), (k1, k1, 2*n_in, n_hidden); 
+    cdims3 = DenseConvDims((nx, ny, 2*n_in, batchsize), (k1, k1, 2*n_in, n_hidden);
         stride=(s1, s1), padding=(p1 ,p1))
 
     return ResidualBlock(W1, W2, W3, b1, b2, fan, cdims1, cdims2, cdims3)
@@ -115,11 +115,11 @@ function ResidualBlock(W1, W2, W3, b1, b2, nx, ny, batchsize; p1=1, p2=1, s1=1, 
     # Dimensions for convolutions
     k1, n_in, n_hidden = size(W1)[2:4]
     k2 = size(W2)[1]
-    cdims1 = DenseConvDims((nx, ny, n_in, batchsize), (k1, k1, n_in, n_hidden); 
+    cdims1 = DenseConvDims((nx, ny, n_in, batchsize), (k1, k1, n_in, n_hidden);
         stride=(s1, s1), padding=(p1, p1))
-    cdims2 = DenseConvDims((Int(nx/s1), Int(ny/s1), n_hidden, batchsize), 
+    cdims2 = DenseConvDims((Int(nx/s1), Int(ny/s1), n_hidden, batchsize),
         (k2, k2, n_hidden, n_hidden); stride=(s2, s2), padding=(p2, p2))
-    cdims3 = DenseConvDims((nx, ny, 2*n_in, batchsize), (k1, k1, 2*n_in, n_hidden); 
+    cdims3 = DenseConvDims((nx, ny, 2*n_in, batchsize), (k1, k1, 2*n_in, n_hidden);
         stride=(s1, s1), padding=(p1, p1))
 
     return ResidualBlock(W1, W2, W3, b1, b2, fan, cdims1, cdims2, cdims3)
@@ -139,11 +139,11 @@ function ResidualBlock(nx, ny, nz, n_in, n_hidden, batchsize; k1=3, k2=3, p1=1, 
     b2 = Parameter(zeros(Float32, n_hidden))
 
     # Dimensions for convolutions
-    cdims1 = DenseConvDims((nx, ny, nz, n_in, batchsize), (k1, k1, k1, n_in, n_hidden); 
+    cdims1 = DenseConvDims((nx, ny, nz, n_in, batchsize), (k1, k1, k1, n_in, n_hidden);
         stride=(s1, s1, s1), padding=(p1, p1, p1))
-    cdims2 = DenseConvDims((Int(nx/s1), Int(ny/s1), Int(nz/s1), n_hidden, batchsize), 
+    cdims2 = DenseConvDims((Int(nx/s1), Int(ny/s1), Int(nz/s1), n_hidden, batchsize),
         (k2, k2, k2, n_hidden, n_hidden); stride=(s2, s2, s2), padding=(p2, p2, p2))
-    cdims3 = DenseConvDims((nx, ny, nz, 2*n_in, batchsize), (k1, k1, k1, 2*n_in, n_hidden); 
+    cdims3 = DenseConvDims((nx, ny, nz, 2*n_in, batchsize), (k1, k1, k1, 2*n_in, n_hidden);
         stride=(s1, s1, s1), padding=(p1, p1, p1))
 
     return ResidualBlock(W1, W2, W3, b1, b2, fan, cdims1, cdims2, cdims3)
@@ -163,11 +163,11 @@ function ResidualBlock(W1, W2, W3, b1, b2, nx::Int64, ny::Int64, nz::Int64, batc
     # Dimensions for convolutions
     k1, n_in, n_hidden = size(W1)[3:5]
     k2 = size(W2)[1]
-    cdims1 = DenseConvDims((nx, ny, nz, n_in, batchsize), (k1, k1, n_in, n_hidden); 
+    cdims1 = DenseConvDims((nx, ny, nz, n_in, batchsize), (k1, k1, k1, n_in, n_hidden);
         stride=(s1, s1, s1), padding=(p1, p1, p1))
-    cdims2 = DenseConvDims((Int(nx/s1), Int(ny/s1), Int(nz/s1), n_hidden, batchsize), 
+    cdims2 = DenseConvDims((Int(nx/s1), Int(ny/s1), Int(nz/s1), n_hidden, batchsize),
         (k2, k2, k2, n_hidden, n_hidden); stride=(s2, s2, s2), padding=(p2, p2, p2))
-    cdims3 = DenseConvDims((nx, ny, nz, 2*n_in, batchsize), (k1, k1, k1, 2*n_in, n_hidden); 
+    cdims3 = DenseConvDims((nx, ny, nz, 2*n_in, batchsize), (k1, k1, k1, 2*n_in, n_hidden);
         stride=(s1, s1, s1), padding=(p1, p1, p1))
 
     return ResidualBlock(W1, W2, W3, b1, b2, fan, cdims1, cdims2, cdims3)
@@ -184,7 +184,7 @@ function forward(X1::AbstractArray{Float32, 4}, RB::ResidualBlock; save=false)
 
     Y2 = X2 + conv(X2, RB.W2.data, RB.cdims2) .+ reshape(RB.b2.data, 1, 1, :, 1)
     X3 = ReLU(Y2)
-    
+
     Y3 = ∇conv_data(X3, RB.W3.data, RB.cdims3)
     RB.fan == true ? (X4 = ReLU(Y3)) : (X4 = GaLU(Y3))
 
@@ -203,7 +203,7 @@ function forward(X1::AbstractArray{Float32, 5}, RB::ResidualBlock; save=false)
 
     Y2 = X2 + conv(X2, RB.W2.data, RB.cdims2) .+ reshape(RB.b2.data, 1, 1, 1, :, 1)
     X3 = ReLU(Y2)
-    
+
     Y3 = ∇conv_data(X3, RB.W3.data, RB.cdims3)
     RB.fan == true ? (X4 = ReLU(Y3)) : (X4 = GaLU(Y3))
 
@@ -228,12 +228,12 @@ function backward(ΔX4::AbstractArray{Float32, 4}, X1::AbstractArray{Float32, 4}
     ΔY2 = ReLUgrad(ΔX3, Y2)
     ΔX2 = ∇conv_data(ΔY2, RB.W2.data, RB.cdims2) + ΔY2
     ΔW2 = ∇conv_filter(X2, ΔY2, RB.cdims2)
-    Δb2 = sum(ΔY2, dims=(1,2,4))[1,1,:,1]
+    Δb2 = sum(ΔY2, dims=[1,2,4])[1,1,:,1]
 
     ΔY1 = ReLUgrad(ΔX2, Y1)
     ΔX1 = ∇conv_data(ΔY1, RB.W1.data, RB.cdims1)
     ΔW1 = ∇conv_filter(X1, ΔY1, RB.cdims1)
-    Δb1 = sum(ΔY1, dims=(1,2,4))[1,1,:,1]
+    Δb1 = sum(ΔY1, dims=[1,2,4])[1,1,:,1]
 
     # Set gradients
     RB.W1.grad = ΔW1
@@ -259,12 +259,12 @@ function backward(ΔX4::AbstractArray{Float32, 5}, X1::AbstractArray{Float32, 5}
     ΔY2 = ReLUgrad(ΔX3, Y2)
     ΔX2 = ∇conv_data(ΔY2, RB.W2.data, RB.cdims2) + ΔY2
     ΔW2 = ∇conv_filter(X2, ΔY2, RB.cdims2)
-    Δb2 = sum(ΔY2, dims=(1,2,3,5))[1,1,1,:,1]
+    Δb2 = sum(ΔY2, dims=[1,2,3,5])[1,1,1,:,1]
 
     ΔY1 = ReLUgrad(ΔX2, Y1)
     ΔX1 = ∇conv_data(ΔY1, RB.W1.data, RB.cdims1)
     ΔW1 = ∇conv_filter(X1, ΔY1, RB.cdims1)
-    Δb1 = sum(ΔY1, dims=(1,2,3,5))[1,1,1,:,1]
+    Δb1 = sum(ΔY1, dims=[1,2,3,5])[1,1,1,:,1]
 
     # Set gradients
     RB.W1.grad = ΔW1

--- a/src/networks/invertible_network_hyperbolic.jl
+++ b/src/networks/invertible_network_hyperbolic.jl
@@ -87,7 +87,7 @@ function NetworkHyperbolic(nx::Int64, ny::Int64, n_in::Int64, batchsize::Int64, 
         count += 1
         if K > 1
             for j=2:K
-                HL[count] = HyperbolicLayer(Int(nx/2^(i-1)), Int(ny/2^(i-1)), Int(n_in*4^(i-1)), batchsize, k, s, p;
+                HL[count] = HyperbolicLayer(Int(nx/2^i), Int(ny/2^i), Int(n_in*4^i), batchsize, k, s, p;
                     action="same", α=α, hidden_factor=hidden_factor)
                 count += 1
             end

--- a/src/utils/activation_functions.jl
+++ b/src/utils/activation_functions.jl
@@ -53,6 +53,7 @@ end
  See also: [`LeakyReLUinv`](@ref), [`LeakyReLUgrad`](@ref)
 """
 function LeakyReLU(x; slope=0.01f0)
+    p_mask = (sign.(x) .+ 1)/2
     return max.(0f0, x).*p_mask + slope*min.(0f0, x).*(1 .- p_mask)
 end
 

--- a/src/utils/activation_functions.jl
+++ b/src/utils/activation_functions.jl
@@ -18,9 +18,7 @@ export GaLU, GaLUgrad
  See also: [`ReLUgrad`](@ref)
 """
 function ReLU(x)
-    y = 0f0.*x
-    y[x.>=0f0] = x[x.>=0f0]
-    return y
+    return max.(0f0, x)
 end
 
 """
@@ -41,9 +39,7 @@ end
  See also: [`ReLU`](@ref)
 """
 function ReLUgrad(Δy, x)
-    Δx = 0f0.*x
-    Δx[x.>=0f0] = Δy[x.>=0f0]
-    return Δx
+    return Δy.*(sign.(x) .+ 1)/2
 end
 
 ###############################################################################
@@ -57,10 +53,7 @@ end
  See also: [`LeakyReLUinv`](@ref), [`LeakyReLUgrad`](@ref)
 """
 function LeakyReLU(x; slope=0.01f0)
-    y = 0f0.*x
-    y[x.>=0f0] = x[x.>=0f0]
-    y[x.<0f0] = slope*x[x.<0f0]
-    return y
+    return max.(0f0, x).*p_mask + slope*min.(0f0, x).*(1 .- p_mask)
 end
 
 """
@@ -82,16 +75,16 @@ end
 
  Backpropagate data residual through leaky ReLU function.
 
- *Input*: 
- 
- - `Δy`: residual 
- 
+ *Input*:
+
+ - `Δy`: residual
+
  - `y`: original output
 
  - `slope`: slope of non-active part of ReLU
 
  *Output*:
- 
+
  - `Δx`: backpropagated residual
 
  See also: [`LeakyReLU`](@ref), [`LeakyReLUinv`](@ref)
@@ -141,16 +134,16 @@ end
 
  Backpropagate data residual through Sigmoid function.
 
- *Input*: 
- 
- - `Δy`: residual 
- 
+ *Input*:
+
+ - `Δy`: residual
+
  - `y`: original output
 
  - `x`: original input, if y not available (in this case, set y=nothing)
 
  *Output*:
- 
+
  - `Δx`: backpropagated residual
 
  See also: [`Sigmoid`](@ref), [`SigmoidInv`](@ref)
@@ -191,14 +184,14 @@ end
 
  Backpropagate data residual through GaLU activation.
 
- *Input*: 
- 
- - `Δy`: residual 
- 
+ *Input*:
+
+ - `Δy`: residual
+
  - `x`: original input (since not invertible)
 
  *Output*:
- 
+
  - `Δx`: backpropagated residual
 
  See also: [`GaLU`](@ref)

--- a/src/utils/activation_functions.jl
+++ b/src/utils/activation_functions.jl
@@ -53,8 +53,7 @@ end
  See also: [`LeakyReLUinv`](@ref), [`LeakyReLUgrad`](@ref)
 """
 function LeakyReLU(x; slope=0.01f0)
-    p_mask = (sign.(x) .+ 1)/2
-    return max.(0f0, x).*p_mask + slope*min.(0f0, x).*(1 .- p_mask)
+    return max.(0f0, x) + slope*min.(0f0, x)
 end
 
 """
@@ -65,10 +64,7 @@ end
  See also: [`LeakyReLU`](@ref), [`LeakyReLUgrad`](@ref)
 """
 function LeakyReLUinv(y; slope=0.01f0)
-    x = 0f0.*y
-    x[y.>=0f0] = y[y.>=0f0]
-    x[y.<0f0] = 1f0./slope*y[y.<0f0]
-    return x
+    return max.(0f0, y) + (1f0/slope)*min.(0f0, y)
 end
 
 """
@@ -92,10 +88,8 @@ end
 """
 function LeakyReLUgrad(Δy, y; slope=0.01f0)
     x = LeakyReLUinv(y; slope=slope)  # recompute forward state
-    Δx = 0f0.*y
-    Δx[x.>=0f0] = Δy[x.>=0f0]
-    Δx[x.<0f0] = slope*Δy[x.<0f0]
-    return Δx
+    p_mask = (sign.(x) .+ 1f0)/2f0
+    return Δy.*p_mask + slope*Δy.*(1f0 .- p_mask)
 end
 
 

--- a/src/utils/cuda.jl
+++ b/src/utils/cuda.jl
@@ -1,6 +1,7 @@
 using CUDA
 
-convert_cu(in_a, X) =  X isa CuArray ? cu(in_a) : in_a
+export convert_cu, cuzeros, cuones
 
-cuzeros(X, args...) = X isa CuArray ? CuArrays.fill(0f0, args) : zeros(Float32, args)
-cuones(X, args...) = X isa CuArray ? CuArrays.fill(1f0, args) : ones(Float32, args)
+convert_cu(in_a, X) =  X isa CuArray ? cu(in_a) : in_a
+cuzeros(X, args...) = X isa CuArray ? CUDA.zeros(args) : zeros(Float32, args)
+cuones(X, args...) = X isa CuArray ? CUDA.ones(args) : ones(Float32, args)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,45 +1,49 @@
 # Tests for invertible neural network module
 # Author: Philipp Witte, pwitte3@gatech.edu
 # Date: January 2020
-
 using InvertibleNetworks, Test
 
 test_suite = "all"   # "all", "layers" or "networks"
 
+layers = ["test_utils/test_objectives.jl",
+          "test_utils/test_nnlib_convolution.jl",
+          "test_utils/test_activations.jl",
+          "test_utils/test_squeeze.jl",
+          # Layers
+          "test_layers/test_residual_block.jl",
+          "test_layers/test_flux_block.jl",
+          "test_layers/test_householder_convolution.jl",
+          "test_layers/test_coupling_layer_basic.jl",
+          "test_layers/test_coupling_layer_irim.jl",
+          "test_layers/test_coupling_layer_glow.jl",
+          "test_layers/test_coupling_layer_hint.jl",
+          "test_layers/test_coupling_layer_slim.jl",
+          "test_layers/test_coupling_layer_slim_learned.jl",
+          "test_layers/test_conditional_layer_hint.jl",
+          "test_layers/test_conditional_layer_slim.jl",
+          "test_layers/test_conditional_res_block.jl",
+          "test_layers/test_hyperbolic_layer.jl",
+          "test_layers/test_actnorm.jl"]
+
+networks = ["test_networks/test_unrolled_loop.jl",
+            "test_networks/test_generator.jl",
+            "test_networks/test_glow.jl",
+            "test_networks/test_hyperbolic_network.jl",
+            "test_networks/test_conditional_hint_network.jl"]
+
 if test_suite == "all" || test_suite == "layers"
-    @testset "Test individual layers" begin
-
-        # Utils
-        include("test_utils/test_objectives.jl")
-        include("test_utils/test_nnlib_convolution.jl")
-        include("test_utils/test_activations.jl")
-        include("test_utils/test_squeeze.jl")
-
-        # Layers
-        include("test_layers/test_residual_block.jl")
-        include("test_layers/test_flux_block.jl")
-        include("test_layers/test_householder_convolution.jl")
-        include("test_layers/test_coupling_layer_basic.jl")
-        include("test_layers/test_coupling_layer_irim.jl")
-        include("test_layers/test_coupling_layer_glow.jl")
-        include("test_layers/test_coupling_layer_hint.jl")
-        include("test_layers/test_coupling_layer_slim.jl")
-        include("test_layers/test_coupling_layer_slim_learned.jl")
-        include("test_layers/test_conditional_layer_hint.jl")
-        include("test_layers/test_conditional_layer_slim.jl")
-        include("test_layers/test_conditional_res_block.jl")
-	    include("test_layers/test_hyperbolic_layer.jl")
-        include("test_layers/test_actnorm.jl")
+    for t=layers
+        @testset  "Test $t" begin
+            include(t)
+        end
     end
 end
 
 # Networks
 if test_suite == "all" || test_suite == "networks"
-    @testset "Test networks" begin
-        include("test_networks/test_unrolled_loop.jl")
-        include("test_networks/test_generator.jl")
-        include("test_networks/test_glow.jl")
-        include("test_networks/test_hyperbolic_network.jl")
-        include("test_networks/test_conditional_hint_network.jl")
+    for t=networks
+        @testset  "Test $t" begin
+            include(t)
+        end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,7 +28,7 @@ if test_suite == "all" || test_suite == "layers"
         include("test_layers/test_conditional_layer_hint.jl")
         include("test_layers/test_conditional_layer_slim.jl")
         include("test_layers/test_conditional_res_block.jl")
-	include("test_layers/test_hyperbolic_layer.jl")
+	    include("test_layers/test_hyperbolic_layer.jl")
         include("test_layers/test_actnorm.jl")
     end
 end

--- a/test/test_networks/test_hyperbolic_network.jl
+++ b/test/test_networks/test_hyperbolic_network.jl
@@ -1,8 +1,5 @@
 using InvertibleNetworks, LinearAlgebra, Test, Random
 
-# Random seed
-Random.seed!(100)
-
 # Data
 nx = 16
 ny = 16
@@ -13,16 +10,20 @@ X = randn(Float32, nx, ny, n_in, batchsize)
 # Network
 nscales = 2
 steps_per_scale = 4
-H = NetworkHyperbolic(nx, ny, n_in, batchsize, nscales, steps_per_scale; α=1f-1, hidden_factor=32, ncenter=2)
-
+nc = 2
+hf = 32
+α0 = .2f0
+H = NetworkHyperbolic(nx, ny, n_in, batchsize, nscales, steps_per_scale; α=α0, hidden_factor=hf, ncenter=nc)
 
 ###################################################################################################
 # Test invertibility
 
 X_ = H.inverse(H.forward(X)[1])
+@show norm(X - X_), norm(X)
 @test isapprox(norm(X - X_)/norm(X), 0f0; atol=1e-2)
 
 X_ = H.forward(H.inverse(X))[1]
+@show norm(X - X_), norm(X)
 @test isapprox(norm(X - X_)/norm(X), 0f0; atol=1e-2)
 
 
@@ -63,27 +64,31 @@ end
 @test isapprox(err1[end] / (err1[1]/2^(maxiter-1)), 1f0; atol=1f1)
 @test isapprox(err2[end] / (err2[1]/4^(maxiter-1)), 1f0; atol=1f1)
 
+@show rate_1 = sum(err1[1:end-1]./err1[2:end])/(maxiter - 1)
+@show rate_2 = sum(err2[1:end-1]./err2[2:end])/(maxiter - 1)
 
 # Gradient test w.r.t. weights of hyperbolic network
-H = NetworkHyperbolic(nx, ny, n_in, batchsize, nscales, steps_per_scale; α=1f-1, hidden_factor=32, ncenter=2)
-H0 = NetworkHyperbolic(nx, ny, n_in, batchsize, nscales, steps_per_scale; α=1f-1, hidden_factor=32, ncenter=2)
+H = NetworkHyperbolic(nx, ny, n_in, batchsize, nscales, steps_per_scale; α=α0, hidden_factor=hf, ncenter=nc)
+H0 = NetworkHyperbolic(nx, ny, n_in, batchsize, nscales, steps_per_scale; α=α0, hidden_factor=hf, ncenter=nc)
 H.forward(X)
 H0.forward(X)   # evaluate to initialize actnorm layer
-Hini = deepcopy(H0)
 
-dW = H.HL[1].W.data - H0.HL[1].W.data
-ds = H.AL.s.data - H0.AL.s.data
+W0 = H0.HL[1].W.data
+s0 = H0.AL.s.data
+dW = randn(Float32, size(W0)) #H.HL[1].W.data - H0.HL[1].W.data
+ds = randn(Float32, size(s0)) #H.AL.s.data - H0.AL.s.data
 
 f0, ΔX, ΔW, Δs = loss(H0, X)
 h = 0.01f0
-maxiter = 6
+maxiter = 6 
 err3 = zeros(Float32, maxiter)
 err4 = zeros(Float32, maxiter)
 
 print("\nGradient test invertible layer\n")
+
 for j=1:maxiter
-    H0.HL[1].W.data = Hini.HL[1].W.data + h*dW
-    H0.AL.s.data = Hini.AL.s.data + h*ds
+    H0.HL[1].W.data = W0 + h*dW
+    H0.AL.s.data = s0 + h*ds
     f = loss(H0, X)[1]
     err3[j] = abs(f - f0)
     err4[j] = abs(f - f0 - h*dot(dW, ΔW)- h*dot(ds, Δs))
@@ -91,5 +96,8 @@ for j=1:maxiter
     global h = h/2f0
 end
 
-@test isapprox(err3[end] / (err3[1]/2^(maxiter-1)), 1f0; atol=1f1)
-@test isapprox(err4[end] / (err4[1]/4^(maxiter-1)), 1f0; atol=1f1)
+@show rate_1 = sum(err3[1:end-1]./err3[2:end])/(maxiter - 1)
+@show rate_2 = sum(err4[1:end-1]./err4[2:end])/(maxiter - 1)
+
+@test isapprox(err3[end] / (err3[1]/2^(maxiter-1)), 1f0; atol=2f1)
+@test isapprox(err4[end] / (err4[1]/4^(maxiter-1)), 1f0; atol=2f1)

--- a/test/test_utils/test_nnlib_convolution.jl
+++ b/test/test_utils/test_nnlib_convolution.jl
@@ -70,7 +70,7 @@ function objective(W, b, X, Y)
     ΔY = (conv(X, W, cdims) .+ reshape(b, 1, 1, :, 1)) - Y
     f = .5f0*norm(ΔY)^2f0
     gW = ∇conv_filter(X, ΔY, cdims)
-    gb = sum(ΔY, dims=(1,2,4))[1, 1, :, 1]
+    gb = sum(ΔY, dims=[1,2,4])[1, 1, :, 1]
     return f, gW, gb
 end
 
@@ -90,7 +90,7 @@ for j=1:maxiter
     err2[j] = abs(f - f0 - h*dot(dW, gW))
     print(err1[j], "; ", err2[j], "\n")
     global h = h/2f0
-end   
+end
 
 @test isapprox(err1[end] / (err1[1]/2^(maxiter-1)), 1f0; atol=1f1)
 @test isapprox(err2[end] / (err2[1]/4^(maxiter-1)), 1f0; atol=1f1)
@@ -110,7 +110,7 @@ for j=1:maxiter
     err4[j] = abs(f - f0 - h*dot(db, gb))
     print(err3[j], "; ", err4[j], "\n")
     global h = h/2f0
-end   
+end
 
 @test isapprox(err3[end] / (err3[1]/2^(maxiter-1)), 1f0; atol=1f1)
 @test isapprox(err4[end] / (err4[1]/4^(maxiter-1)), 1f0; atol=1f1)
@@ -137,7 +137,7 @@ function objective(W, b, X, Y)
     ΔY = (conv(X, W, cdims) .+ reshape(b, 1, 1, 1, :, 1)) - Y
     f = .5f0*norm(ΔY)^2f0
     gW = ∇conv_filter(X, ΔY, cdims)
-    gb = sum(ΔY, dims=(1,2,3,5))[1, 1, 1, :, 1]
+    gb = sum(ΔY, dims=[1,2,3,5])[1, 1, 1, :, 1]
     return f, gW, gb
 end
 
@@ -157,7 +157,7 @@ for j=1:maxiter
     err2[j] = abs(f - f0 - h*dot(dW, gW))
     print(err1[j], "; ", err2[j], "\n")
     global h = h/2f0
-end   
+end
 
 @test isapprox(err1[end] / (err1[1]/2^(maxiter-1)), 1f0; atol=1f1)
 @test isapprox(err2[end] / (err2[1]/4^(maxiter-1)), 1f0; atol=1f1)
@@ -177,7 +177,7 @@ for j=1:maxiter
     err4[j] = abs(f - f0 - h*dot(db, gb))
     print(err3[j], "; ", err4[j], "\n")
     global h = h/2f0
-end   
+end
 
 @test isapprox(err3[end] / (err3[1]/2^(maxiter-1)), 1f0; atol=1f1)
 @test isapprox(err4[end] / (err4[1]/4^(maxiter-1)), 1f0; atol=1f1)


### PR DESCRIPTION
Mainly, the current changes are related to `src/utils/activation_functions.jl` where the element-wise operations are replaced. In addition, I changed the way we were inputting `dims` argument (tuple) for several operations, such as `sum`, `mean`, and `var` since  `CUDA.jl` required an array rather than tuple. There was one small fix in the 3D `ResidualBlock` in [line 166](https://github.com/slimgroup/InvertibleNetworks.jl/blob/master/src/layers/layer_residual_block.jl#L166)
