### PR TITLE
add scale and shifted sigmoid

### DIFF
--- a/test/test_utils/test_activations.jl
+++ b/test/test_utils/test_activations.jl
@@ -142,6 +142,53 @@ end
 @test isapprox(err1[end] / (err1[1]/2^(maxiter-1)), 1f0; atol=1f1)
 @test isapprox(err2[end] / (err2[1]/4^(maxiter-1)), 1f0; atol=1f1)
 
+# Shifted and Scaled Sigmoid
+low = 0.5f0
+high = 1f0
+
+nx = 12
+ny = 12
+n_in = 4
+batchsize = 2
+
+X = glorot_uniform(nx, ny, n_in, batchsize)
+X0 = glorot_uniform(nx, ny, n_in, batchsize)
+dX = X - X0
+
+# Invertibility
+err = norm(X - SigmoidInv(Sigmoid(X; low=low, high=high); low=low, high=high)) / norm(X)
+@test isapprox(err, 0f0, atol=1f-5)
+
+# Gradient test sigmoid
+function objective(X, Y)
+    Y0 = Sigmoid(X; low=low, high=high)
+    ΔY = Y0 - Y
+    f = .5f0*norm(ΔY)^2
+    ΔX = SigmoidGrad(ΔY, Y0; low=low, high=high)
+    return f, ΔX
+end
+
+# Observed data
+Y = Sigmoid(X; low=low, high=high)
+
+# Gradient test for X
+maxiter = 5
+print("\nGradient test scaled and shifted Sigmoid\n")
+f0, ΔX = objective(X0, Y)
+h = .1f0
+err1 = zeros(Float32, maxiter)
+err2 = zeros(Float32, maxiter)
+for j=1:maxiter
+    f = objective(X0 + h*dX, Y)[1]
+    err1[j] = abs(f - f0)
+    err2[j] = abs(f - f0 - h*dot(dX, ΔX))
+    print(err1[j], "; ", err2[j], "\n")
+    global h = h/2f0
+end
+
+@test isapprox(err1[end] / (err1[1]/2^(maxiter-1)), 1f0; atol=1f1)
+@test isapprox(err2[end] / (err2[1]/4^(maxiter-1)), 1f0; atol=1f1)
+
 
 ###############################################################################
 # Gated linear unit (GaLU)

--- a/test/test_utils/test_activations.jl
+++ b/test/test_utils/test_activations.jl
@@ -159,7 +159,7 @@ dX = X - X0
 err = norm(X - SigmoidInv(Sigmoid(X; low=low, high=high); low=low, high=high)) / norm(X)
 @test isapprox(err, 0f0, atol=1f-5)
 
-# Gradient test sigmoid
+# Gradient test Shifted and Scaled Sigmoid
 function objective(X, Y)
     Y0 = Sigmoid(X; low=low, high=high)
     ΔY = Y0 - Y


### PR DESCRIPTION
According to the theory in https://arxiv.org/pdf/2006.09347.pdf and from the success of https://arxiv.org/pdf/2007.02462.pdf we add a tunable parameter to the sigmoid activation layer which shifts and scales such that output is between `[a,b]` where `b` is chosen to be `1` and `a` needs to be greater than 0. Good choice of `a` seems to be `a=0.5`
