### PR TITLE
Conditional glow network and flexible residual block

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InvertibleNetworks"
 uuid = "b7115f24-5f92-4794-81e8-23b0ddb121d3"
 authors = ["Philipp Witte <p.witte@ymail.com>", "Ali Siahkoohi <alisk@gatech.edu>", "Mathias Louboutin <mlouboutin3@gatech.edu>", "Gabrio Rizzuti <g.rizzuti@umcutrecht.nl>", "Rafael Orozco <rorozco@gatech.edu>", "Felix J. herrmann <fherrmann@gatech.edu>"]
-version = "2.1.5"
+version = "2.2.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/src/InvertibleNetworks.jl
+++ b/src/InvertibleNetworks.jl
@@ -68,7 +68,9 @@ include("networks/invertible_network_glow.jl")  # Glow: Dinh et al. (2017), King
 include("networks/invertible_network_hyperbolic.jl")    # Hyperbolic: Lensink et al. (2019)
 
 # Conditional layers and nets
+include("conditional_layers/conditional_layer_glow.jl")
 include("conditional_layers/conditional_layer_hint.jl")
+include("networks/invertible_network_conditional_glow.jl")
 include("networks/invertible_network_conditional_hint.jl")
 include("networks/invertible_network_conditional_hint_multiscale.jl")
 

--- a/src/conditional_layers/conditional_layer_glow.jl
+++ b/src/conditional_layers/conditional_layer_glow.jl
@@ -1,0 +1,157 @@
+# Affine coupling layer from Dinh et al. (2017)
+# Includes 1x1 convolution from in Putzky and Welling (2019)
+# Author: Philipp Witte, pwitte3@gatech.edu
+# Date: January 2020
+
+export ConditionalLayerGlow, ConditionalLayerGlow3D
+
+
+"""
+    CL = CouplingLayerGlow(C::Conv1x1, RB::ResidualBlock; logdet=false)
+
+or
+
+    CL = CouplingLayerGlow(n_in, n_hidden; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1, logdet=false, ndims=2) (2D)
+
+    CL = CouplingLayerGlow(n_in, n_hidden; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1, logdet=false, ndims=3) (3D)
+    
+    CL = CouplingLayerGlow3D(n_in, n_hidden; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1, logdet=false) (3D)
+
+ Create a Real NVP-style invertible coupling layer based on 1x1 convolutions and a residual block.
+
+ *Input*:
+
+ - `C::Conv1x1`: 1x1 convolution layer
+
+ - `RB::ResidualBlock`: residual block layer consisting of 3 convolutional layers with ReLU activations.
+
+ - `logdet`: bool to indicate whether to compte the logdet of the layer
+
+ or
+
+ - `n_in`, `n_hidden`: number of input and hidden channels
+
+ - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third
+    operator, `k2` is the kernel size of the second operator.
+
+ - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
+
+ - `ndims` : number of dimensions
+
+ *Output*:
+
+ - `CL`: Invertible Real NVP coupling layer.
+
+ *Usage:*
+
+ - Forward mode: `Y, logdet = CL.forward(X)`    (if constructed with `logdet=true`)
+
+ - Inverse mode: `X = CL.inverse(Y)`
+
+ - Backward mode: `ΔX, X = CL.backward(ΔY, Y)`
+
+ *Trainable parameters:*
+
+ - None in `CL` itself
+
+ - Trainable parameters in residual block `CL.RB` and 1x1 convolution layer `CL.C`
+
+ See also: [`Conv1x1`](@ref), [`ResidualBlock`](@ref), [`get_params`](@ref), [`clear_grad!`](@ref)
+"""
+struct ConditionalLayerGlow <: NeuralNetLayer
+    C::Conv1x1
+    RB::Union{ResidualBlock, FluxBlock}
+    logdet::Bool
+    activation::ActivationFunction
+end
+
+@Flux.functor ConditionalLayerGlow
+
+# Constructor from 1x1 convolution and residual block
+function ConditionalLayerGlow(C::Conv1x1, RB::ResidualBlock; logdet=false, activation::ActivationFunction=SigmoidLayer())
+    RB.fan == false && throw("Set ResidualBlock.fan == true")
+    return ConditionalLayerGlow(C, RB, logdet, activation)
+end
+
+# Constructor from 1x1 convolution and residual Flux block
+ConditionalLayerGlow(C::Conv1x1, RB::FluxBlock; logdet=false, activation::ActivationFunction=SigmoidLayer()) = CouplingLayerGlow(C, RB, logdet, activation)
+
+# Constructor from input dimensions
+function ConditionalLayerGlow(n_in::Int64, n_cond::Int64, n_hidden::Int64; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1, logdet=false, activation::ActivationFunction=SigmoidLayer(), ndims=2)
+
+    # 1x1 Convolution and residual block for invertible layer
+    C  = Conv1x1(n_in)
+    RB = ResidualBlock(Int(n_in/2)+n_cond,n_in, n_hidden; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, fan=true, ndims=ndims)
+
+    return ConditionalLayerGlow(C, RB, logdet, activation)
+end
+
+ConditionalLayerGlow3D(args...;kw...) = ConditionalLayerGlow(args...; kw..., ndims=3)
+
+# Forward pass: Input X, Output Y
+function forward(X::AbstractArray{T, 4}, C::AbstractArray{T, 4}, L::ConditionalLayerGlow) where T
+
+    X_ = L.C.forward(X)
+    X1, X2 = tensor_split(X_)
+
+    Y2 = copy(X2)
+    logS_T = L.RB.forward(tensor_cat(X2,C))
+    logS, log_T = tensor_split(logS_T)
+
+    Sm = L.activation.forward(logS)
+    Tm = log_T
+    Y1 = Sm.*X1 + Tm
+
+    Y = tensor_cat(Y1, Y2)
+
+    L.logdet == true ? (return Y, glow_logdet_forward(Sm)) : (return Y)
+end
+
+# Inverse pass: Input Y, Output X
+function inverse(Y::AbstractArray{T, 4}, C::AbstractArray{T, 4}, L::ConditionalLayerGlow; save=false) where T
+
+    # Get dimensions
+    k = Int(L.C.k/2)
+    Y1, Y2 = tensor_split(Y)
+
+    X2 = copy(Y2)
+    logS_T = L.RB.forward(tensor_cat(X2,C))
+    logS, log_T = tensor_split(logS_T)
+
+    Sm = L.activation.forward(logS)
+    Tm = log_T
+    X1 = (Y1 - Tm) ./ (Sm .+ eps(T)) # add epsilon to avoid division by 0
+
+    X_ = tensor_cat(X1, X2)
+    X = L.C.inverse(X_)
+
+    save == true ? (return X, X1, X2, Sm) : (return X)
+end
+
+# Backward pass: Input (ΔY, Y), Output (ΔX, X)
+function backward(ΔY::AbstractArray{T, 4}, Y::AbstractArray{T, 4}, C::AbstractArray{T, 4}, L::ConditionalLayerGlow;) where T
+
+    # Recompute forward state
+    X, X1, X2, S = inverse(Y, C, L; save=true)
+
+    # Backpropagate residual
+    ΔY1, ΔY2 = tensor_split(ΔY)
+    ΔT = copy(ΔY1)
+    ΔS = ΔY1 .* X1
+
+    if L.logdet
+        ΔS -= glow_logdet_backward(S)
+    end
+
+    ΔX1 = ΔY1 .* S
+
+    ΔX2_ΔC = L.RB.backward(cat(L.activation.backward(ΔS, S), ΔT; dims=3), (tensor_cat(X2, C)))
+    ΔX2 = tensor_split(ΔX2_ΔC; split_index=Int(size(ΔY)[4-1]/2))[1] # should be N-dim array
+    ΔX2 += ΔY2
+  
+    ΔX = L.C.inverse((tensor_cat(ΔX1, ΔX2), tensor_cat(X1, X2)))[1]
+
+    return ΔX, X
+end

--- a/src/layers/invertible_layer_glow.jl
+++ b/src/layers/invertible_layer_glow.jl
@@ -83,7 +83,7 @@ function CouplingLayerGlow(n_in::Int64, n_hidden::Int64; k1=3, k2=1, p1=1, p2=0,
 
     # 1x1 Convolution and residual block for invertible layer
     C = Conv1x1(n_in)
-    RB = ResidualBlock(Int(n_in/2),n_in, n_hidden; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, fan=true, ndims=ndims)
+    RB = ResidualBlock(Int(n_in/2), n_hidden; n_out=n_in, k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, fan=true, ndims=ndims)
 
     return CouplingLayerGlow(C, RB, logdet, activation)
 end

--- a/src/layers/invertible_layer_glow.jl
+++ b/src/layers/invertible_layer_glow.jl
@@ -83,7 +83,7 @@ function CouplingLayerGlow(n_in::Int64, n_hidden::Int64; k1=3, k2=1, p1=1, p2=0,
 
     # 1x1 Convolution and residual block for invertible layer
     C = Conv1x1(n_in)
-    RB = ResidualBlock(Int(n_in/2), n_hidden; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, fan=true, ndims=ndims)
+    RB = ResidualBlock(Int(n_in/2),n_in, n_hidden; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, fan=true, ndims=ndims)
 
     return CouplingLayerGlow(C, RB, logdet, activation)
 end

--- a/src/layers/layer_residual_block.jl
+++ b/src/layers/layer_residual_block.jl
@@ -20,7 +20,13 @@ or
 
  *Input*:
 
- - `n_in`, `n_hidden`: number of input and hidden channels
+ - `n_in`: number of input channels
+
+ - `n_hidden`: number of hidden channels
+
+ - `n_out`: number of ouput channels
+
+ - `activation`: activation type between conv layers and final output
 
  - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third
     operator, `k2` is the kernel size of the second operator.
@@ -67,6 +73,7 @@ struct ResidualBlock <: NeuralNetLayer
     fan::Bool
     strides
     pad
+    activation::ActivationFunction
 end
 
 @Flux.functor ResidualBlock
@@ -75,7 +82,8 @@ end
 #  Constructors
 
 # Constructor
-function ResidualBlock(n_in, n_hidden; n_out=nothing, k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, fan=false, ndims=2)
+function ResidualBlock(n_in, n_hidden; n_out=nothing, activation::ActivationFunction=ReLUlayer(), k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, fan=false, ndims=2)
+    # default/legacy behaviour
     isnothing(n_out) && (n_out = 2*n_in)
 
     k1 = Tuple(k1 for i=1:ndims)
@@ -87,11 +95,11 @@ function ResidualBlock(n_in, n_hidden; n_out=nothing, k1=3, k2=3, p1=1, p2=1, s1
     b1 = Parameter(zeros(Float32, n_hidden))
     b2 = Parameter(zeros(Float32, n_hidden))
 
-    return ResidualBlock(W1, W2, W3, b1, b2, fan, (s1, s2), (p1, p2))
+    return ResidualBlock(W1, W2, W3, b1, b2, fan, (s1, s2), (p1, p2), activation)
 end
 
 # Constructor for given weights
-function ResidualBlock(W1, W2, W3, b1, b2; p1=1, p2=1, s1=1, s2=1, fan=false, ndims=2)
+function ResidualBlock(W1, W2, W3, b1, b2; activation::ActivationFunction=ReLUlayer(), p1=1, p2=1, s1=1, s2=1, fan=false, ndims=2)
 
     # Make weights parameters
     W1 = Parameter(W1)
@@ -100,7 +108,7 @@ function ResidualBlock(W1, W2, W3, b1, b2; p1=1, p2=1, s1=1, s2=1, fan=false, nd
     b1 = Parameter(b1)
     b2 = Parameter(b2)
 
-    return ResidualBlock(W1, W2, W3, b1, b2, fan, (s1, s2), (p1, p2))
+    return ResidualBlock(W1, W2, W3, b1, b2, fan, (s1, s2), (p1, p2),activation)
 end
 
 ResidualBlock3D(args...; kw...) = ResidualBlock(args...; kw..., ndims=3)
@@ -112,17 +120,17 @@ function forward(X1::AbstractArray{T, N}, RB::ResidualBlock; save=false) where {
     inds =[i!=(N-1) ? 1 : Colon() for i=1:N]
 
     Y1 = conv(X1, RB.W1.data; stride=RB.strides[1], pad=RB.pad[1]) .+ reshape(RB.b1.data, inds...)
-    X2 = ReLU(Y1)
+    X2 = RB.activation.forward(Y1)
 
     Y2 = X2 + conv(X2, RB.W2.data; stride=RB.strides[2], pad=RB.pad[2]) .+ reshape(RB.b2.data, inds...)
-    X3 = ReLU(Y2)
+    X3 = RB.activation.forward(Y2)
 
     cdims3 = DCDims(X1, RB.W3.data; stride=RB.strides[1], padding=RB.pad[1])
     Y3 = ∇conv_data(X3, RB.W3.data, cdims3)
     # Return if only recomputing state
     save && (return Y1, Y2, Y3)
     # Finish forward
-    RB.fan == true ? (return ReLU(Y3)) : (return GaLU(Y3))
+    RB.fan == true ? (return RB.activation.forward(Y3)) : (return GaLU(Y3))
 end
 
 # Backward
@@ -139,18 +147,18 @@ function backward(ΔX4::AbstractArray{T, N}, X1::AbstractArray{T, N},
     cdims3 = DCDims(X1, RB.W3.data;  stride=RB.strides[1], padding=RB.pad[1])
 
     # Backpropagate residual ΔX4 and compute gradients
-    RB.fan == true ? (ΔY3 = ReLUgrad(ΔX4, Y3)) : (ΔY3 = GaLUgrad(ΔX4, Y3))
+    RB.fan == true ? (ΔY3 = RB.activation.backward(ΔX4, Y3)) : (ΔY3 = GaLUgrad(ΔX4, Y3))
     ΔX3 = conv(ΔY3, RB.W3.data, cdims3)
-    ΔW3 = ∇conv_filter(ΔY3, ReLU(Y2), cdims3)
+    ΔW3 = ∇conv_filter(ΔY3, RB.activation.forward(Y2), cdims3)
 
-    ΔY2 = ReLUgrad(ΔX3, Y2)
+    ΔY2 = RB.activation.backward(ΔX3, Y2)
     ΔX2 = ∇conv_data(ΔY2, RB.W2.data, cdims2) + ΔY2
-    ΔW2 = ∇conv_filter(ReLU(Y1), ΔY2, cdims2)
+    ΔW2 = ∇conv_filter(RB.activation.forward(Y1), ΔY2, cdims2)
     Δb2 = sum(ΔY2, dims=dims)[inds...]
 
     cdims1 = DenseConvDims(X1, RB.W1.data; stride=RB.strides[1], padding=RB.pad[1])
 
-    ΔY1 = ReLUgrad(ΔX2, Y1)
+    ΔY1 = RB.activation.backward(ΔX2, Y1)
     ΔX1 = ∇conv_data(ΔY1, RB.W1.data, cdims1)
     ΔW1 = ∇conv_filter(X1, ΔY1, cdims1)
     Δb1 = sum(ΔY1, dims=dims)[inds...]
@@ -178,22 +186,22 @@ function jacobian(ΔX1::AbstractArray{T, N}, Δθ::Array{Parameter, 1},
 
     Y1 = conv(X1, RB.W1.data, cdims1) .+ reshape(RB.b1.data, inds...)
     ΔY1 = conv(ΔX1, RB.W1.data, cdims1) + conv(X1, Δθ[1].data, cdims1) .+ reshape(Δθ[4].data, inds...)
-    X2 = ReLU(Y1)
-    ΔX2 = ReLUgrad(ΔY1, Y1)
+    X2 = RB.activation.forward(Y1)
+    ΔX2 = RB.activation.backward(ΔY1, Y1)
 
     cdims2 = DenseConvDims(X2, RB.W2.data; stride=RB.strides[2], padding=RB.pad[2])
 
     Y2 = X2 + conv(X2, RB.W2.data, cdims2) .+ reshape(RB.b2.data, inds...)
     ΔY2 = ΔX2 + conv(ΔX2, RB.W2.data, cdims2) + conv(X2, Δθ[2].data, cdims2) .+ reshape(Δθ[5].data, inds...)
-    X3 = ReLU(Y2)
-    ΔX3 = ReLUgrad(ΔY2, Y2)
+    X3 = RB.activation.forward(Y2)
+    ΔX3 = RB.activation.backward(ΔY2, Y2)
 
     cdims3 = DCDims(X1, RB.W3.data; nc=2*size(X1, N-1), stride=RB.strides[1], padding=RB.pad[1])
     Y3 = ∇conv_data(X3, RB.W3.data, cdims3)
     ΔY3 = ∇conv_data(ΔX3, RB.W3.data, cdims3) + ∇conv_data(X3, Δθ[3].data, cdims3)
     if RB.fan == true
-        X4 = ReLU(Y3)
-        ΔX4 = ReLUgrad(ΔY3, Y3)
+        X4 = RB.activation.forward(Y3)
+        ΔX4 = RB.activation.backward(ΔY3, Y3)
     else
         ΔX4, X4 = GaLUjacobian(ΔY3, Y3)
     end

--- a/src/layers/layer_residual_block.jl
+++ b/src/layers/layer_residual_block.jl
@@ -75,7 +75,8 @@ end
 #  Constructors
 
 # Constructor
-function ResidualBlock(n_in, n_out, n_hidden; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, fan=false, ndims=2)
+function ResidualBlock(n_in, n_hidden; n_out=nothing, k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, fan=false, ndims=2)
+    isnothing(n_out) && (n_out = 2*n_in)
 
     k1 = Tuple(k1 for i=1:ndims)
     k2 = Tuple(k2 for i=1:ndims)

--- a/src/layers/layer_residual_block.jl
+++ b/src/layers/layer_residual_block.jl
@@ -75,14 +75,14 @@ end
 #  Constructors
 
 # Constructor
-function ResidualBlock(n_in, n_hidden; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, fan=false, ndims=2)
+function ResidualBlock(n_in, n_out, n_hidden; k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, fan=false, ndims=2)
 
     k1 = Tuple(k1 for i=1:ndims)
     k2 = Tuple(k2 for i=1:ndims)
     # Initialize weights
     W1 = Parameter(glorot_uniform(k1..., n_in, n_hidden))
     W2 = Parameter(glorot_uniform(k2..., n_hidden, n_hidden))
-    W3 = Parameter(glorot_uniform(k1..., 2*n_in, n_hidden))
+    W3 = Parameter(glorot_uniform(k1..., n_out, n_hidden))
     b1 = Parameter(zeros(Float32, n_hidden))
     b2 = Parameter(zeros(Float32, n_hidden))
 
@@ -116,7 +116,7 @@ function forward(X1::AbstractArray{T, N}, RB::ResidualBlock; save=false) where {
     Y2 = X2 + conv(X2, RB.W2.data; stride=RB.strides[2], pad=RB.pad[2]) .+ reshape(RB.b2.data, inds...)
     X3 = ReLU(Y2)
 
-    cdims3 = DCDims(X1, RB.W3.data; nc=2*size(X1, N-1), stride=RB.strides[1], padding=RB.pad[1])
+    cdims3 = DCDims(X1, RB.W3.data; stride=RB.strides[1], padding=RB.pad[1])
     Y3 = ∇conv_data(X3, RB.W3.data, cdims3)
     # Return if only recomputing state
     save && (return Y1, Y2, Y3)
@@ -135,7 +135,7 @@ function backward(ΔX4::AbstractArray{T, N}, X1::AbstractArray{T, N},
 
     # Cdims
     cdims2 = DenseConvDims(Y2, RB.W2.data; stride=RB.strides[2], padding=RB.pad[2])
-    cdims3 = DCDims(X1, RB.W3.data; nc=2*size(X1, N-1), stride=RB.strides[1], padding=RB.pad[1])
+    cdims3 = DCDims(X1, RB.W3.data;  stride=RB.strides[1], padding=RB.pad[1])
 
     # Backpropagate residual ΔX4 and compute gradients
     RB.fan == true ? (ΔY3 = ReLUgrad(ΔX4, Y3)) : (ΔY3 = GaLUgrad(ΔX4, Y3))

--- a/src/networks/invertible_network_conditional_glow.jl
+++ b/src/networks/invertible_network_conditional_glow.jl
@@ -1,0 +1,172 @@
+# Invertible network based on Glow (Kingma and Dhariwal, 2018)
+# Includes 1x1 convolution and residual block
+# Author: Philipp Witte, pwitte3@gatech.edu
+# Date: February 2020
+
+export NetworkConditionalGlow, NetworkConditionalGlow3D
+
+"""
+    G = NetworkGlow(n_in, n_hidden, L, K; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1)
+
+    G = NetworkGlow3D(n_in, n_hidden, L, K; k1=3, k2=1, p1=1, p2=0, s1=1, s2=1)
+
+ Create an invertible network based on the Glow architecture. Each flow step in the inner loop 
+ consists of an activation normalization layer, followed by an invertible coupling layer with
+ 1x1 convolutions and a residual block. The outer loop performs a squeezing operation prior 
+ to the inner loop, and a splitting operation afterwards.
+
+ *Input*: 
+
+ - 'n_in': number of input channels
+
+ - `n_hidden`: number of hidden units in residual blocks
+
+ - `L`: number of scales (outer loop)
+
+ - `K`: number of flow steps per scale (inner loop)
+
+ - `split_scales`: if true, perform squeeze operation which halves spatial dimensions and duplicates channel dimensions
+    then split output in half along channel dimension after each scale. Feed one half through the next layers,
+    while saving the remaining channels for the output.
+
+ - `k1`, `k2`: kernel size of convolutions in residual block. `k1` is the kernel of the first and third 
+ operator, `k2` is the kernel size of the second operator.
+
+ - `p1`, `p2`: padding for the first and third convolution (`p1`) and the second convolution (`p2`)
+
+ - `s1`, `s2`: stride for the first and third convolution (`s1`) and the second convolution (`s2`)
+
+ - `ndims` : number of dimensions
+
+ - `squeeze_type` : squeeze type that happens at each multiscale level
+
+ *Output*:
+ 
+ - `G`: invertible Glow network.
+
+ *Usage:*
+
+ - Forward mode: `Y, logdet = G.forward(X)`
+
+ - Backward mode: `ΔX, X = G.backward(ΔY, Y)`
+
+ *Trainable parameters:*
+
+ - None in `G` itself
+
+ - Trainable parameters in activation normalizations `G.AN[i,j]` and coupling layers `G.C[i,j]`,
+   where `i` and `j` range from `1` to `L` and `K` respectively.
+
+ See also: [`ActNorm`](@ref), [`CouplingLayerGlow!`](@ref), [`get_params`](@ref), [`clear_grad!`](@ref)
+"""
+struct NetworkConditionalGlow <: InvertibleNetwork
+    AN::AbstractArray{ActNorm, 2}
+    CL::AbstractArray{ConditionalLayerGlow, 2}
+    Z_dims::Union{Array{Array, 1}, Nothing}
+    L::Int64
+    K::Int64
+    squeezer::Squeezer
+    split_scales::Bool
+end
+
+@Flux.functor NetworkConditionalGlow
+
+# Constructor
+function NetworkConditionalGlow(n_in,n_cond, n_hidden, L, K; split_scales=false, k1=3, k2=1, p1=1, p2=0, s1=1, s2=1, ndims=2, squeezer::Squeezer=ShuffleLayer(), activation::ActivationFunction=SigmoidLayer())
+    AN = Array{ActNorm}(undef, L, K)    # activation normalization
+    CL = Array{ConditionalLayerGlow}(undef, L, K)  # coupling layers w/ 1x1 convolution and residual block
+ 
+    if split_scales
+        Z_dims = fill!(Array{Array}(undef, L-1), [1,1]) #fill in with dummy values so that |> gpu accepts it   # save dimensions for inverse/backward pass
+        channel_factor = 4
+    else
+        Z_dims = nothing
+        channel_factor = 1
+    end
+
+    for i=1:L
+        n_in *= channel_factor # squeeze if split_scales is turned on
+        n_cond *= channel_factor # squeeze if split_scales is turned on
+        for j=1:K
+            AN[i, j] = ActNorm(n_in; logdet=true)
+            CL[i, j] = ConditionalLayerGlow(n_in, n_cond, n_hidden; k1=k1, k2=k2, p1=p1, p2=p2, s1=s1, s2=s2, logdet=true, activation=activation, ndims=ndims)
+        end
+        (i < L && split_scales) && (n_in = Int64(n_in/2)) # split
+    end
+
+    return NetworkConditionalGlow(AN, CL, Z_dims, L, K, squeezer, split_scales)
+end
+
+NetworkConditionalGlow3D(args; kw...) = NetworkConditionalGlow(args...; kw..., ndims=3)
+
+# Forward pass and compute logdet
+function forward(X::AbstractArray{T, N}, C::AbstractArray{T, N}, G::NetworkConditionalGlow) where {T, N}
+    G.split_scales && (Z_save = array_of_array(X, G.L-1))
+    orig_shape = size(X)
+
+    logdet = 0
+    for i=1:G.L
+        (G.split_scales) && (X = G.squeezer.forward(X))
+        (G.split_scales) && (C = G.squeezer.forward(C))
+        for j=1:G.K            
+            X, logdet1 = G.AN[i, j].forward(X)
+            X, logdet2 = G.CL[i, j].forward(X, C)
+            logdet += (logdet1 + logdet2)
+        end
+        if G.split_scales && i < G.L    # don't split after last iteration
+            X, Z = tensor_split(X)
+            Z_save[i] = Z
+            G.Z_dims[i] = collect(size(Z))
+        end
+    end
+    G.split_scales && (X = reshape(cat_states(Z_save, X),orig_shape))
+    return X, C, logdet
+end
+
+# Inverse pass 
+function inverse(X::AbstractArray{T, N}, C::AbstractArray{T, N}, G::NetworkConditionalGlow) where {T, N}
+    G.split_scales && ((Z_save, X) = split_states(X[:], G.Z_dims))
+    for i=G.L:-1:1
+        if G.split_scales && i < G.L
+            X = tensor_cat(X, Z_save[i])
+        end
+        for j=G.K:-1:1
+            X = G.CL[i, j].inverse(X,C)
+            X = G.AN[i, j].inverse(X)
+        end
+
+        (G.split_scales) && (X = G.squeezer.inverse(X))
+        (G.split_scales) && (C = G.squeezer.inverse(C))
+    end
+    return X
+end
+
+# Backward pass and compute gradients
+function backward(ΔX::AbstractArray{T, N}, X::AbstractArray{T, N}, C::AbstractArray{T, N}, G::NetworkConditionalGlow) where {T, N}
+    
+    # Split data and gradients
+    if G.split_scales
+        ΔZ_save, ΔX = split_states(ΔX[:], G.Z_dims)
+        Z_save, X = split_states(X[:], G.Z_dims)
+    end
+
+    for i=G.L:-1:1
+        if G.split_scales && i < G.L
+            X  = tensor_cat(X, Z_save[i])
+            ΔX = tensor_cat(ΔX, ΔZ_save[i])
+        end
+        for j=G.K:-1:1
+            
+            ΔX, X = G.CL[i, j].backward(ΔX, X, C)
+            ΔX, X = G.AN[i, j].backward(ΔX, X)
+            
+        end
+
+        if G.split_scales 
+          C = G.squeezer.inverse(C)
+          X = G.squeezer.inverse(X)
+          ΔX = G.squeezer.inverse(ΔX)
+        end
+    end
+    return ΔX, X
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ layers = ["test_layers/test_residual_block.jl",
           "test_layers/test_coupling_layer_irim.jl",
           "test_layers/test_coupling_layer_glow.jl",
           "test_layers/test_coupling_layer_hint.jl",
+          "test_layers/test_conditional_layer_glow.jl",
           "test_layers/test_conditional_layer_hint.jl",
           "test_layers/test_conditional_res_block.jl",
           "test_layers/test_hyperbolic_layer.jl",
@@ -40,7 +41,8 @@ networks = ["test_networks/test_unrolled_loop.jl",
             "test_networks/test_hyperbolic_network.jl",
             "test_networks/test_multiscale_hint_network.jl",
             "test_networks/test_multiscale_conditional_hint_network.jl",
-            "test_networks/test_conditional_hint_network.jl"]
+            "test_networks/test_conditional_hint_network.jl",
+            "test_networks/test_conditional_glow_network.jl"]
 
 
 if test_suite == "all" || test_suite == "basics"

--- a/test/test_layers/test_conditional_layer_glow.jl
+++ b/test/test_layers/test_conditional_layer_glow.jl
@@ -26,7 +26,7 @@ dX = X - X0
 
 # 1x1 convolution and residual blocks
 C = Conv1x1(k)
-RB = ResidualBlock(Int(k/2)+n_cond, k, n_hidden; k1=3, k2=3, p1=1, p2=1, fan=true)
+RB = ResidualBlock(Int(k/2)+n_cond, n_hidden; n_out=k, k1=3, k2=3, p1=1, p2=1, fan=true)
 L = ConditionalLayerGlow(C, RB; logdet=true)
 
 X_ = L.inverse(L.forward(X, Cond)[1], Cond)
@@ -51,7 +51,7 @@ end
 
 # Invertible layers
 C0 = Conv1x1(k)
-RB0 = ResidualBlock(Int(k/2)+n_cond, k, n_hidden; k1=3, k2=3, p1=1, p2=1, fan=true)
+RB0 = ResidualBlock(Int(k/2)+n_cond, n_hidden; n_out=k, k1=3, k2=3, p1=1, p2=1, fan=true)
 L01 = ConditionalLayerGlow(C0, RB; logdet=true)
 L02 = ConditionalLayerGlow(C, RB0; logdet=true)
 

--- a/test/test_layers/test_conditional_layer_glow.jl
+++ b/test/test_layers/test_conditional_layer_glow.jl
@@ -1,0 +1,136 @@
+# Invertible CNN layer from Dinh et al. (2017)/Kingma and Dhariwal (2018)
+# Author: Philipp Witte, pwitte3@gatech.edu
+# Date: January 2020
+
+using InvertibleNetworks, LinearAlgebra, Test, Random
+
+# Random seed
+Random.seed!(11)
+
+###################################################################################################
+# Test invertibility
+
+# Input
+nx = 24
+ny = 24
+k = 4
+n_cond = k
+n_hidden = 4
+batchsize = 2
+
+# Input images
+X = randn(Float32, nx, ny, k, batchsize)
+Cond = randn(Float32, nx, ny, k, batchsize)
+X0 = randn(Float32, nx, ny, k, batchsize)
+dX = X - X0
+
+# 1x1 convolution and residual blocks
+C = Conv1x1(k)
+RB = ResidualBlock(Int(k/2)+n_cond, k, n_hidden; k1=3, k2=3, p1=1, p2=1, fan=true)
+L = ConditionalLayerGlow(C, RB; logdet=true)
+
+X_ = L.inverse(L.forward(X, Cond)[1], Cond)
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1e-2)
+
+X_ = L.forward(L.inverse(X, Cond), Cond)[1]
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1e-2)
+
+###################################################################################################
+# Gradient tests
+
+# Loss Function
+function loss(L, X, Y, Cond)
+    Y_, logdet = L.forward(X, Cond)
+    f = mse(Y_, Y) - logdet
+    ΔY = ∇mse(Y_, Y)
+    ΔX = L.backward(ΔY, Y_, Cond)[1]
+
+    # Pass back gradients w.r.t. input X and from the residual block and 1x1 conv. layer
+    return f, ΔX, L.C.v1.grad, L.C.v2.grad, L.C.v3.grad, L.RB.W1.grad, L.RB.W2.grad, L.RB.W3.grad
+end
+
+# Invertible layers
+C0 = Conv1x1(k)
+RB0 = ResidualBlock(Int(k/2)+n_cond, k, n_hidden; k1=3, k2=3, p1=1, p2=1, fan=true)
+L01 = ConditionalLayerGlow(C0, RB; logdet=true)
+L02 = ConditionalLayerGlow(C, RB0; logdet=true)
+
+# Gradient test w.r.t. input X0
+Y = L.forward(X, Cond)[1]
+f0, ΔX = loss(L, X0, Y, Cond)[1:2]
+h = 0.1f0
+maxiter = 6
+err1 = zeros(Float32, maxiter)
+err2 = zeros(Float32, maxiter)
+
+print("\nGradient test coupling layer\n")
+for j=1:maxiter
+    f = loss(L, X0 + h*dX, Y, Cond)[1]
+    err1[j] = abs(f - f0)
+    err2[j] = abs(f - f0 - h*dot(dX, ΔX))
+    print(err1[j], "; ", err2[j], "\n")
+    global h = h/2f0
+end
+
+@test isapprox(err1[end] / (err1[1]/2^(maxiter-1)), 1f0; atol=1f0)
+@test isapprox(err2[end] / (err2[1]/4^(maxiter-1)), 1f0; atol=1f0)
+
+
+
+# Gradient test w.r.t. weights of residual block
+Y = L.forward(X, Cond)[1]
+Lini = deepcopy(L02)
+dW1 = L.RB.W1.data - L02.RB.W1.data
+dW2 = L.RB.W2.data - L02.RB.W2.data
+dW3 = L.RB.W3.data - L02.RB.W3.data
+
+f0, ΔX, Δv1, Δv2, Δv3, ΔW1, ΔW2, ΔW3 = loss(L02, X, Y, Cond)
+h = 0.1f0
+maxiter = 4
+err3 = zeros(Float32, maxiter)
+err4 = zeros(Float32, maxiter)
+
+print("\nGradient test coupling layer\n")
+for j=1:maxiter
+    L02.RB.W1.data = Lini.RB.W1.data + h*dW1
+    L02.RB.W2.data = Lini.RB.W2.data + h*dW2
+    L02.RB.W3.data = Lini.RB.W3.data + h*dW3
+    f = loss(L02, X, Y, Cond)[1]
+    err3[j] = abs(f - f0)
+    err4[j] = abs(f - f0 - h*dot(dW1, ΔW1) - h*dot(dW2, ΔW2) - h*dot(dW3, ΔW3))
+    print(err3[j], "; ", err4[j], "\n")
+    global h = h/2f0
+end
+
+@test isapprox(err3[end] / (err3[1]/2^(maxiter-1)), 1f0; atol=1f0)
+@test isapprox(err4[end] / (err4[1]/4^(maxiter-1)), 1f0; atol=1f0)
+
+
+# Gradient test w.r.t. 1x1 conv weights
+Y = L.forward(X, Cond)[1]
+Lini = deepcopy(L01)
+dv1 = C.v1.data - C0.v1.data
+dv2 = C.v2.data - C0.v2.data
+dv3 = C.v3.data - C0.v3.data
+
+f0, ΔX, Δv1, Δv2, Δv3, ΔW1, ΔW2, ΔW3 = loss(L01, X, Y, Cond)
+h = 0.01f0
+maxiter = 4
+err5 = zeros(Float32, maxiter)
+err6 = zeros(Float32, maxiter)
+
+print("\nGradient test coupling layer\n")
+for j=1:maxiter
+    L01.C.v1.data = Lini.C.v1.data + h*dv1
+    L01.C.v2.data = Lini.C.v2.data + h*dv2
+    L01.C.v3.data = Lini.C.v3.data + h*dv3
+    f = loss(L01, X, Y, Cond)[1]
+    err5[j] = abs(f - f0)
+    err6[j] = abs(f - f0 - h*dot(dv1, Δv1) - h*dot(dv2, Δv2) - h*dot(dv3, Δv3))
+    print(err5[j], "; ", err6[j], "\n")
+    global h = h/2f0
+end
+
+@test isapprox(err5[end] / (err5[1]/2^(maxiter-1)), 1f0; atol=1f0)
+@test isapprox(err6[end] / (err6[1]/4^(maxiter-1)), 1f0; atol=1f0)
+

--- a/test/test_layers/test_residual_block.jl
+++ b/test/test_layers/test_residual_block.jl
@@ -14,160 +14,165 @@ batchsize = 2
 k1 = 3
 k2 = 3
 
-# Input
-X = glorot_uniform(nx, ny, n_in, batchsize)
-X0 = glorot_uniform(nx, ny, n_in, batchsize)
-dX = (X - X0)/norm(X0)
 
-# Weights
-W1 = glorot_uniform(k1, k1, n_in, n_hidden)
-W2 = glorot_uniform(k2, k2, n_hidden, n_hidden)
-W3 = glorot_uniform(k1, k1, 2*n_in, n_hidden)
-b1 = glorot_uniform(n_hidden)
-b2 = glorot_uniform(n_hidden)
 
-W01 = glorot_uniform(k1, k1, n_in, n_hidden)
-W02 = glorot_uniform(k2, k2, n_hidden, n_hidden)
-W03 = glorot_uniform(k1, k1, 2*n_in, n_hidden)
-b01 = glorot_uniform(n_hidden)
-b02 = glorot_uniform(n_hidden)
+for activation in [ReLUlayer(), LeakyReLUlayer()]
+    println("Testing activation $(activation)")
+    # Input
+    X = glorot_uniform(nx, ny, n_in, batchsize);
+    X0 = glorot_uniform(nx, ny, n_in, batchsize);
+    dX = (X - X0)/norm(X0)
 
-dW1 = W1 - W01; dW1 *= norm(W01)/norm(dW1)
-dW2 = W2 - W02; dW2 *= norm(W02)/norm(dW2)
-dW3 = W3 - W03; dW3 *= norm(W03)/norm(dW3)
-db1 = b1 - b01; db1 *= norm(b01)/norm(db1)
-db2 = b2 - b02; db2 *= norm(b02)/norm(db2)
+    # Weights
+    W1 = glorot_uniform(k1, k1, n_in, n_hidden);
+    W2 = glorot_uniform(k2, k2, n_hidden, n_hidden);
+    W3 = glorot_uniform(k1, k1, 2*n_in, n_hidden);
+    b1 = glorot_uniform(n_hidden);
+    b2 = glorot_uniform(n_hidden);
 
-# Residual blocks
-RB = ResidualBlock(W1, W2, W3, b1, b2)   # true weights
+    W01 = glorot_uniform(k1, k1, n_in, n_hidden);
+    W02 = glorot_uniform(k2, k2, n_hidden, n_hidden);
+    W03 = glorot_uniform(k1, k1, 2*n_in, n_hidden);
+    b01 = glorot_uniform(n_hidden);
+    b02 = glorot_uniform(n_hidden);
 
-# Observed data
-Y = RB.forward(X)
+    dW1 = W1 - W01; dW1 *= norm(W01)/norm(dW1);
+    dW2 = W2 - W02; dW2 *= norm(W02)/norm(dW2);
+    dW3 = W3 - W03; dW3 *= norm(W03)/norm(dW3);
+    db1 = b1 - b01; db1 *= norm(b01)/norm(db1);
+    db2 = b2 - b02; db2 *= norm(b02)/norm(db2);
 
-function loss(RB, X, Y)
-    Y_ = RB.forward(X)
-    ΔY = Y_ - Y
-    f = .5f0*norm(ΔY)^2
-    ΔX = RB.backward(ΔY, X)
-    return f, ΔX, RB.W1.grad, RB.W2.grad, RB.W3.grad, RB.b1.grad, RB.b2.grad
+    # Residual blocks
+    RB = ResidualBlock(W1, W2, W3, b1, b2;activation=activation)   # true weights
+
+    # Observed data
+    Y = RB.forward(X)
+
+    function loss(RB, X, Y)
+        Y_ = RB.forward(X)
+        ΔY = Y_ - Y
+        f = .5f0*norm(ΔY)^2
+        ΔX = RB.backward(ΔY, X)
+        return f, ΔX, RB.W1.grad, RB.W2.grad, RB.W3.grad, RB.b1.grad, RB.b2.grad
+    end
+
+
+    ###################################################################################################
+    # Gradient tests
+
+    # Gradient test w.r.t. input
+    f0, ΔX = loss(RB, X0, Y)[1:2]
+    h = 0.1f0
+    maxiter = 5
+    err1 = zeros(Float32, maxiter)
+    err2 = zeros(Float32, maxiter)
+
+    print("\nGradient test convolutions\n")
+    for j=1:maxiter
+        f = loss(RB, X0 + h*dX, Y)[1]
+        err1[j] = abs(f - f0)
+        err2[j] = abs(f - f0 - h*dot(dX, ΔX))
+        print(err1[j], "; ", err2[j], "\n")
+        h = h/2f0
+    end
+
+    @test isapprox(err1[end] / (err1[1]/2^(maxiter-1)), 1f0; atol=1f1)
+    @test isapprox(err2[end] / (err2[1]/4^(maxiter-1)), 1f0; atol=1f1)
+
+
+    # Gradient test for weights
+    RB0 = ResidualBlock(W01, W02, W03, b1, b2)   # initial weights
+    f0, ΔX, ΔW1, ΔW2, ΔW3 = loss(RB0, X0, Y)[1:5]
+    h = 0.1f0
+    maxiter = 5
+    err3 = zeros(Float32, maxiter)
+    err4 = zeros(Float32, maxiter)
+
+    print("\nGradient test convolutions\n")
+    for j=1:maxiter
+        RB0.W1.data = W01 + h*dW1
+        RB0.W2.data = W02 + h*dW2
+        RB0.W3.data = W03 + h*dW3
+        f = loss(RB0, X0, Y)[1]
+        err3[j] = abs(f - f0)
+        err4[j] = abs(f - f0 - h*dot(dW1, ΔW1) - h*dot(dW2, ΔW2) - h*dot(dW3, ΔW3))
+        print(err3[j], "; ", err4[j], "\n")
+        h = h/2f0
+    end
+
+    @test isapprox(err3[end] / (err3[1]/2^(maxiter-1)), 1f0; atol=1f1)
+    @test isapprox(err4[end] / (err4[1]/4^(maxiter-1)), 1f0; atol=1f1)
+
+
+    # Gradient test for bias
+    RB0 = ResidualBlock(W1, W2, W3, b01, b02)
+    f0, ΔX, ΔW1, ΔW2, ΔW3, Δb1, Δb2 = loss(RB0, X0, Y)
+    h = 0.1f0
+    maxiter = 5
+    err5 = zeros(Float32, maxiter)
+    err6 = zeros(Float32, maxiter)
+    print("\nGradient test convolutions\n")
+    for j=1:maxiter
+        RB0.b1.data = b01 + h*db1
+        RB0.b2.data = b02 + h*db2
+        f = loss(RB0, X0, Y)[1]
+        err5[j] = abs(f - f0)
+        err6[j] = abs(f - f0 - h*dot(db1, Δb1) - h*dot(db2, Δb2))
+        print(err5[j], "; ", err6[j], "\n")
+        h = h/2f0
+    end
+
+    @test isapprox(err5[end] / (err5[1]/2^(maxiter-1)), 1f0; atol=1f1)
+    @test isapprox(err6[end] / (err6[1]/4^(maxiter-1)), 1f0; atol=1f1)
+
+
+    ###################################################################################################
+    # Jacobian-related tests
+
+    # Gradient test
+
+    # Initialization
+    W1 = glorot_uniform(k1, k1, n_in, n_hidden)
+    W2 = glorot_uniform(k2, k2, n_hidden, n_hidden)
+    W3 = glorot_uniform(k1, k1, 2*n_in, n_hidden)
+    b1 = glorot_uniform(n_hidden)
+    b2 = glorot_uniform(n_hidden)
+    RB = ResidualBlock(W1, W2, W3, b1, b2; fan=true)
+    θ = deepcopy(get_params(RB))
+    X = randn(Float32, nx, ny, n_in, batchsize)
+
+    # Perturbation (normalized)
+    dθ = [Parameter(dW1)/norm(W1), Parameter(dW2)/norm(W2), Parameter(dW3)/norm(W3), Parameter(db1)/norm(b1), Parameter(db2)/norm(b2)]
+    dX = randn(Float32, nx, ny, n_in, batchsize)/norm(X)
+
+    # Jacobian eval
+    dY, Y = RB.jacobian(dX, dθ, X)
+
+    # Test
+    print("\nJacobian test\n")
+    h = 0.1f0
+    maxiter = 5
+    err7 = zeros(Float32, maxiter)
+    err8 = zeros(Float32, maxiter)
+    for j=1:maxiter
+        set_params!(RB, θ+h*dθ)
+        Y_loc = RB.forward(X+h*dX)
+        err7[j] = norm(Y_loc - Y)
+        err8[j] = norm(Y_loc - Y - h*dY)
+        print(err7[j], "; ", err8[j], "\n")
+        h = h/2f0
+    end
+
+    @test isapprox(err7[end] / (err7[1]/2^(maxiter-1)), 1f0; atol=1f1)
+    @test isapprox(err8[end] / (err8[1]/4^(maxiter-1)), 1f0; atol=1f1)
+
+    # Adjoint test
+
+    set_params!(RB, θ)
+    dY = RB.jacobian(dX, dθ, X)[1]
+    dY_ = randn(Float32, size(dY))
+    dX_, dθ_ = RB.adjointJacobian(dY_, X)
+    a = dot(dY, dY_)
+    b = dot(dX, dX_)+dot(dθ, dθ_)
+    @test isapprox(a, b; rtol=1f-3)
 end
-
-
-###################################################################################################
-# Gradient tests
-
-# Gradient test w.r.t. input
-f0, ΔX = loss(RB, X0, Y)[1:2]
-h = 0.1f0
-maxiter = 5
-err1 = zeros(Float32, maxiter)
-err2 = zeros(Float32, maxiter)
-
-print("\nGradient test convolutions\n")
-for j=1:maxiter
-    f = loss(RB, X0 + h*dX, Y)[1]
-    err1[j] = abs(f - f0)
-    err2[j] = abs(f - f0 - h*dot(dX, ΔX))
-    print(err1[j], "; ", err2[j], "\n")
-    global h = h/2f0
-end
-
-@test isapprox(err1[end] / (err1[1]/2^(maxiter-1)), 1f0; atol=1f1)
-@test isapprox(err2[end] / (err2[1]/4^(maxiter-1)), 1f0; atol=1f1)
-
-
-# Gradient test for weights
-RB0 = ResidualBlock(W01, W02, W03, b1, b2)   # initial weights
-f0, ΔX, ΔW1, ΔW2, ΔW3 = loss(RB0, X0, Y)[1:5]
-h = 0.1f0
-maxiter = 5
-err3 = zeros(Float32, maxiter)
-err4 = zeros(Float32, maxiter)
-
-print("\nGradient test convolutions\n")
-for j=1:maxiter
-    RB0.W1.data = W01 + h*dW1
-    RB0.W2.data = W02 + h*dW2
-    RB0.W3.data = W03 + h*dW3
-    f = loss(RB0, X0, Y)[1]
-    err3[j] = abs(f - f0)
-    err4[j] = abs(f - f0 - h*dot(dW1, ΔW1) - h*dot(dW2, ΔW2) - h*dot(dW3, ΔW3))
-    print(err3[j], "; ", err4[j], "\n")
-    global h = h/2f0
-end
-
-@test isapprox(err3[end] / (err3[1]/2^(maxiter-1)), 1f0; atol=1f1)
-@test isapprox(err4[end] / (err4[1]/4^(maxiter-1)), 1f0; atol=1f1)
-
-
-# Gradient test for bias
-RB0 = ResidualBlock(W1, W2, W3, b01, b02)
-f0, ΔX, ΔW1, ΔW2, ΔW3, Δb1, Δb2 = loss(RB0, X0, Y)
-h = 0.1f0
-maxiter = 5
-err5 = zeros(Float32, maxiter)
-err6 = zeros(Float32, maxiter)
-print("\nGradient test convolutions\n")
-for j=1:maxiter
-    RB0.b1.data = b01 + h*db1
-    RB0.b2.data = b02 + h*db2
-    f = loss(RB0, X0, Y)[1]
-    err5[j] = abs(f - f0)
-    err6[j] = abs(f - f0 - h*dot(db1, Δb1) - h*dot(db2, Δb2))
-    print(err5[j], "; ", err6[j], "\n")
-    global h = h/2f0
-end
-
-@test isapprox(err5[end] / (err5[1]/2^(maxiter-1)), 1f0; atol=1f1)
-@test isapprox(err6[end] / (err6[1]/4^(maxiter-1)), 1f0; atol=1f1)
-
-
-###################################################################################################
-# Jacobian-related tests
-
-# Gradient test
-
-# Initialization
-W1 = glorot_uniform(k1, k1, n_in, n_hidden)
-W2 = glorot_uniform(k2, k2, n_hidden, n_hidden)
-W3 = glorot_uniform(k1, k1, 2*n_in, n_hidden)
-b1 = glorot_uniform(n_hidden)
-b2 = glorot_uniform(n_hidden)
-RB = ResidualBlock(W1, W2, W3, b1, b2; fan=true)
-θ = deepcopy(get_params(RB))
-X = randn(Float32, nx, ny, n_in, batchsize)
-
-# Perturbation (normalized)
-dθ = [Parameter(dW1)/norm(W1), Parameter(dW2)/norm(W2), Parameter(dW3)/norm(W3), Parameter(db1)/norm(b1), Parameter(db2)/norm(b2)]
-dX = randn(Float32, nx, ny, n_in, batchsize)/norm(X)
-
-# Jacobian eval
-dY, Y = RB.jacobian(dX, dθ, X)
-
-# Test
-print("\nJacobian test\n")
-h = 0.1f0
-maxiter = 5
-err7 = zeros(Float32, maxiter)
-err8 = zeros(Float32, maxiter)
-for j=1:maxiter
-    set_params!(RB, θ+h*dθ)
-    Y_loc = RB.forward(X+h*dX)
-    err7[j] = norm(Y_loc - Y)
-    err8[j] = norm(Y_loc - Y - h*dY)
-    print(err7[j], "; ", err8[j], "\n")
-    global h = h/2f0
-end
-
-@test isapprox(err7[end] / (err7[1]/2^(maxiter-1)), 1f0; atol=1f1)
-@test isapprox(err8[end] / (err8[1]/4^(maxiter-1)), 1f0; atol=1f1)
-
-# Adjoint test
-
-set_params!(RB, θ)
-dY = RB.jacobian(dX, dθ, X)[1]
-dY_ = randn(Float32, size(dY))
-dX_, dθ_ = RB.adjointJacobian(dY_, X)
-a = dot(dY, dY_)
-b = dot(dX, dX_)+dot(dθ, dθ_)
-@test isapprox(a, b; rtol=1f-3)

--- a/test/test_networks/test_conditional_glow_network.jl
+++ b/test/test_networks/test_conditional_glow_network.jl
@@ -5,7 +5,7 @@
 using InvertibleNetworks, LinearAlgebra, Test, Random
 
 # Random seed
-Random.seed!(1);
+Random.seed!(2);
 
 # Define network
 nx = 32
@@ -53,10 +53,10 @@ end
 # Gradient test
 
 function loss(G, X, Cond)
-    Y, logdet = G.forward(X, Cond)
+    Y, ZC, logdet = G.forward(X, Cond)
     f = -log_likelihood(Y) - logdet
     ΔY = -∇log_likelihood(Y)
-    ΔX, X_ = G.backward(ΔY, Y, Cond)
+    ΔX, X_ = G.backward(ΔY, Y, ZC)
     return f, ΔX, G.CL[1,1].RB.W1.grad, G.CL[1,1].C.v1.grad
 end
 

--- a/test/test_networks/test_conditional_glow_network.jl
+++ b/test/test_networks/test_conditional_glow_network.jl
@@ -25,8 +25,8 @@ G = NetworkConditionalGlow(n_in, n_cond, n_hidden, L, K)
 X = rand(Float32, nx, ny, n_in, batchsize)
 Cond = rand(Float32, nx, ny, n_cond, batchsize)
 
-Y = G.forward(X,Cond)[1]
-X_ = G.inverse(Y,Cond)
+Y, Cond = G.forward(X,Cond)
+X_ = G.inverse(Y,Cond) # saving the cond is important in split scales because of reshapes
 
 @test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)
 
@@ -39,7 +39,7 @@ gsum = 0
 for p in P
     ~isnothing(p.grad) && (global gsum += 1)
 end
-@test isequal(gsum, L*K*10)
+@test isequal(gsum, L*K*10+2)
 
 clear_grad!(G)
 gsum = 0

--- a/test/test_networks/test_conditional_glow_network.jl
+++ b/test/test_networks/test_conditional_glow_network.jl
@@ -1,0 +1,121 @@
+# Generative model w/ Glow architecture from Kingma & Dhariwal (2018)
+# Author: Philipp Witte, pwitte3@gatech.edu
+# Date: January 2020
+
+using InvertibleNetworks, LinearAlgebra, Test, Random
+
+# Random seed
+Random.seed!(1);
+
+# Define network
+nx = 32
+ny = 32
+n_in = 2
+n_cond = 2
+n_hidden = 4
+batchsize = 2
+L = 2
+K = 2
+
+########################################### Test with split_scales = false #########################
+# Invertibility
+
+# Network and input
+G = NetworkConditionalGlow(n_in, n_cond, n_hidden, L, K)
+X = rand(Float32, nx, ny, n_in, batchsize)
+Cond = rand(Float32, nx, ny, n_cond, batchsize)
+
+Y = G.forward(X,Cond)[1]
+X_ = G.inverse(Y,Cond)
+
+@test isapprox(norm(X - X_)/norm(X), 0f0; atol=1f-5)
+
+###################################################################################################
+# Test gradients are set and cleared
+G.backward(Y, Y, Cond)
+
+P = get_params(G)
+gsum = 0
+for p in P
+    ~isnothing(p.grad) && (global gsum += 1)
+end
+@test isequal(gsum, L*K*10)
+
+clear_grad!(G)
+gsum = 0
+for p in P
+    ~isnothing(p.grad) && (global gsum += 1)
+end
+@test isequal(gsum, 0)
+
+
+###################################################################################################
+# Gradient test
+
+function loss(G, X, Cond)
+    Y, logdet = G.forward(X, Cond)
+    f = -log_likelihood(Y) - logdet
+    ΔY = -∇log_likelihood(Y)
+    ΔX, X_ = G.backward(ΔY, Y, Cond)
+    return f, ΔX, G.CL[1,1].RB.W1.grad, G.CL[1,1].C.v1.grad
+end
+
+# Gradient test w.r.t. input
+G = NetworkConditionalGlow(n_in, n_cond, n_hidden, L, K)
+X = rand(Float32, nx, ny, n_in, batchsize)
+Cond = rand(Float32, nx, ny, n_cond, batchsize)
+X0 = rand(Float32, nx, ny, n_in, batchsize)
+Cond0 = rand(Float32, nx, ny, n_cond, batchsize)
+
+dX = X - X0
+
+f0, ΔX = loss(G, X0, Cond0)[1:2]
+h = 0.1f0
+maxiter = 4
+err1 = zeros(Float32, maxiter)
+err2 = zeros(Float32, maxiter)
+
+print("\nGradient test glow: input\n")
+for j=1:maxiter
+    f = loss(G, X0 + h*dX, Cond0)[1]
+    err1[j] = abs(f - f0)
+    err2[j] = abs(f - f0 - h*dot(dX, ΔX))
+    print(err1[j], "; ", err2[j], "\n")
+    global h = h/2f0
+end
+
+@test isapprox(err1[end] / (err1[1]/2^(maxiter-1)), 1f0; atol=1f0)
+@test isapprox(err2[end] / (err2[1]/4^(maxiter-1)), 1f0; atol=1f0)
+
+
+# Gradient test w.r.t. parameters
+X = rand(Float32, nx, ny, n_in, batchsize)
+G = NetworkConditionalGlow(n_in, n_cond, n_hidden, L, K)
+G0 = NetworkConditionalGlow(n_in, n_cond, n_hidden, L, K)
+Gini = deepcopy(G0)
+
+# Test one parameter from residual block and 1x1 conv
+dW = G.CL[1,1].RB.W1.data - G0.CL[1,1].RB.W1.data
+dv = G.CL[1,1].C.v1.data - G0.CL[1,1].C.v1.data
+
+f0, ΔX, ΔW, Δv = loss(G0, X, Cond)
+h = 0.1f0
+maxiter = 4
+err3 = zeros(Float32, maxiter)
+err4 = zeros(Float32, maxiter)
+
+print("\nGradient test glow: input\n")
+for j=1:maxiter
+    G0.CL[1,1].RB.W1.data = Gini.CL[1,1].RB.W1.data + h*dW
+    G0.CL[1,1].C.v1.data = Gini.CL[1,1].C.v1.data + h*dv
+
+    f = loss(G0, X, Cond)[1]
+    err3[j] = abs(f - f0)
+    err4[j] = abs(f - f0 - h*dot(dW, ΔW) - h*dot(dv, Δv))
+    print(err3[j], "; ", err4[j], "\n")
+    global h = h/2f0
+end
+
+@test isapprox(err3[end] / (err3[1]/2^(maxiter-1)), 1f0; atol=1f0)
+@test isapprox(err4[end] / (err4[1]/4^(maxiter-1)), 1f0; atol=1f0)
+

--- a/test/test_utils/test_jacobian.jl
+++ b/test/test_utils/test_jacobian.jl
@@ -1,7 +1,10 @@
 # Author: Gabrio Rizzuti, grizzuti33@gatech.edu
 # Date: September 2020
 
-using InvertibleNetworks, LinearAlgebra, Test, Statistics
+using InvertibleNetworks, Random, LinearAlgebra, Test, Statistics
+
+# Random seed
+Random.seed!(11)
 
 # Input
 nx = 28


### PR DESCRIPTION
Simple conditional network based on glow coupling layer and the cIIN idea of tensor catting the condition to the input of the residual block. 

Includes an important change to the residual block that allows for user set the size of the output of the RB with keyword argument **n_out**:
```
function ResidualBlock(n_in, n_hidden; n_out=nothing, k1=3, k2=3, p1=1, p2=1, s1=1, s2=1, fan=false, ndims=2)
.
.
.
    W3 = Parameter(glorot_uniform(k1..., n_out, n_hidden))
.
.
.
```
This change should be backwards compatible. 

I want to use this network to showcase the MNIST non-conditional and conditional generation. This network doesn't necessarily perform better than conditional hint (same performance as far as my tests) but is much more lightweight. 