### PR TITLE
LearnableSqueezer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "InvertibleNetworks"
 uuid = "b7115f24-5f92-4794-81e8-23b0ddb121d3"
-authors = ["Philipp Witte <p.witte@ymail.com>", "Ali Siahkoohi <alisk@gatech.edu>", "Mathias Louboutin <mlouboutin3@gatech.edu>", "Gabrio Rizzuti <g.rizzuti@umcutrecht.nl>", "Rafael Orozco <rorozco@gatech.edu>", "Felix J. herrmann <fherrmann@gatech.edu>"]
+authors = ["Philipp Witte <p.witte@ymail.com>", "Ali Siahkoohi <alisk@gatech.edu>", "Mathias Louboutin <mlouboutin3@gatech.edu>", "Gabrio Rizzuti <rizzuti.gabrio@gmail.com>", "Rafael Orozco <rorozco@gatech.edu>", "Felix J. herrmann <fherrmann@gatech.edu>"]
 version = "2.2.6"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "2.2.5"
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ExponentialUtilities = "d4d017d3-3776-5f7e-afef-a10c40355c18"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 JOLI = "bb331ad6-a1cf-11e9-23da-9bcb53c69f6f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ This package uses functions from [NNlib.jl](https://github.com/FluxML/NNlib.jl),
 
  - Philipp Witte, Georgia Institute of Technology (now Microsoft)
 
- - Gabrio Rizzuti, Utrecht University
+ - Gabrio Rizzuti, Georgia Institute of Technology (now Shearwater Geoservices)
 
  - Mathias Louboutin, Georgia Institute of Technology
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,7 +28,7 @@ Pages = ["dimensionality_operations.jl"]
 ```@autodocs
 Modules = [InvertibleNetworks]
 Order  = [:type]
-Filter = t -> t<:NeuralNetLayer
+Filter = t -> t<:InvertibleNetwork
 ```
 
 ## Networks

--- a/src/InvertibleNetworks.jl
+++ b/src/InvertibleNetworks.jl
@@ -38,12 +38,13 @@ end
 
 # Utils
 include("utils/parameter.jl")
+include("utils/neuralnet.jl")
 include("utils/objective_functions.jl")
 include("utils/dimensionality_operations.jl")
 include("utils/activation_functions.jl")
 include("utils/test_distributions.jl")
-include("utils/neuralnet.jl")
 include("utils/invertible_network_sequential.jl")
+
 # AD rules
 include("utils/chainrules.jl")
 

--- a/src/InvertibleNetworks.jl
+++ b/src/InvertibleNetworks.jl
@@ -9,6 +9,7 @@ using LinearAlgebra, Random
 using Statistics, Wavelets
 using JOLI
 using NNlib, Flux, ChainRulesCore
+using ExponentialUtilities
 
 # Overloads and reexports
 import Base.size, Base.length, Base.getindex, Base.reverse, Base.reverse!, Base.getproperty
@@ -61,6 +62,7 @@ include("layers/invertible_layer_irim.jl")
 include("layers/invertible_layer_glow.jl")
 include("layers/invertible_layer_hyperbolic.jl")
 include("layers/invertible_layer_hint.jl")
+include("layers/learnable_squeezer.jl")
 
 # Invertible network architectures
 include("networks/invertible_network_hint_multiscale.jl")

--- a/src/conditional_layers/conditional_layer_glow.jl
+++ b/src/conditional_layers/conditional_layer_glow.jl
@@ -58,7 +58,7 @@ or
 
  See also: [`Conv1x1`](@ref), [`ResidualBlock`](@ref), [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-struct ConditionalLayerGlow <: NeuralNetLayer
+struct ConditionalLayerGlow <: InvertibleNetwork
     C::Conv1x1
     RB::ResidualBlock
     logdet::Bool

--- a/src/conditional_layers/conditional_layer_hint.jl
+++ b/src/conditional_layers/conditional_layer_hint.jl
@@ -51,7 +51,7 @@ export ConditionalLayerHINT, ConditionalLayerHINT3D
 
  See also: [`CouplingLayerBasic`](@ref), [`ResidualBlock`](@ref), [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-mutable struct ConditionalLayerHINT <: NeuralNetLayer
+mutable struct ConditionalLayerHINT <: InvertibleNetwork
     CL_X::CouplingLayerHINT
     CL_Y::CouplingLayerHINT
     CL_YX::CouplingLayerBasic

--- a/src/conditional_layers/conditional_layer_residual_block.jl
+++ b/src/conditional_layers/conditional_layer_residual_block.jl
@@ -46,7 +46,7 @@ or
 
  See also: [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-struct ConditionalResidualBlock <: NeuralNetLayer
+struct ConditionalResidualBlock <: InvertibleNetwork
     W0::Parameter
     W1::Parameter
     W2::Parameter

--- a/src/conditional_layers/conditional_layer_residual_block.jl
+++ b/src/conditional_layers/conditional_layer_residual_block.jl
@@ -46,7 +46,7 @@ or
 
  See also: [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-struct ConditionalResidualBlock <: InvertibleNetwork
+struct ConditionalResidualBlock <: NeuralNetwork
     W0::Parameter
     W1::Parameter
     W2::Parameter

--- a/src/layers/invertible_layer_actnorm.jl
+++ b/src/layers/invertible_layer_actnorm.jl
@@ -39,7 +39,7 @@ export ActNorm, reset!
 
  See also: [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-mutable struct ActNorm <: NeuralNetLayer
+mutable struct ActNorm <: InvertibleNetwork
     k::Integer
     s::Parameter
     b::Parameter

--- a/src/layers/invertible_layer_basic.jl
+++ b/src/layers/invertible_layer_basic.jl
@@ -58,7 +58,7 @@ or
 
  See also: [`ResidualBlock`](@ref), [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-mutable struct CouplingLayerBasic <: NeuralNetLayer
+mutable struct CouplingLayerBasic <: InvertibleNetwork
     RB::Union{ResidualBlock, FluxBlock}
     logdet::Bool
     activation::ActivationFunction

--- a/src/layers/invertible_layer_conv1x1.jl
+++ b/src/layers/invertible_layer_conv1x1.jl
@@ -39,7 +39,7 @@ export Conv1x1
 
  See also: [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-struct Conv1x1 <: NeuralNetLayer
+struct Conv1x1 <: InvertibleNetwork
     k::Integer
     v1::Parameter
     v2::Parameter

--- a/src/layers/invertible_layer_conv1x1.jl
+++ b/src/layers/invertible_layer_conv1x1.jl
@@ -159,8 +159,8 @@ function conv1x1_grad_v(X::AbstractArray{T, N}, ΔY::AbstractArray{T, N},
     n_in, batchsize = size(X)[N-1:N]
     prod_res = cuzeros(X, size(dV1, 1))
     for i=1:batchsize
-        Xi = -2f0*reshape(selectdim(X, N, i), :, n_in)
-        ΔYi = reshape(selectdim(ΔY, N, i), :, n_in)
+        Xi = -2*reshape(selectdim(X, N, i), :, n_in)
+        ΔYi = 1*reshape(selectdim(ΔY, N, i), :, n_in) # 1* force conversion from ReshapedArray to array
         broadcast!(+, dv1, dv1, mat_tens_i(prod_res, Xi, dV1, ΔYi))
         broadcast!(+, dv2, dv2, mat_tens_i(prod_res, Xi, dV2, ΔYi))
         broadcast!(+, dv3, dv3, mat_tens_i(prod_res, Xi, dV3, ΔYi))

--- a/src/layers/invertible_layer_glow.jl
+++ b/src/layers/invertible_layer_glow.jl
@@ -60,7 +60,7 @@ or
 
  See also: [`Conv1x1`](@ref), [`ResidualBlock`](@ref), [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-struct CouplingLayerGlow <: NeuralNetLayer
+struct CouplingLayerGlow <: InvertibleNetwork
     C::Conv1x1
     RB::Union{ResidualBlock, FluxBlock}
     logdet::Bool

--- a/src/layers/invertible_layer_hint.jl
+++ b/src/layers/invertible_layer_hint.jl
@@ -72,8 +72,8 @@ function get_depth(n_in)
 end
 
 # Constructor for given coupling layer and 1 x 1 convolution
-CouplingLayerHINT(CL::AbstractArray{CouplingLayerBasic, 1}, C::Union{Conv1x1, Nothing};
-    logdet=false, permute="none", activation::ActivationFunction=SigmoidLayer()) = CouplingLayerHINT(CL, C, logdet, permute, false)
+CouplingLayerHINT(CL::AbstractArray{CouplingLayerBasic, 1}, C::Union{Conv1x1, Nothing}; logdet=false, permute="none") =
+    CouplingLayerHINT(CL, C, logdet, permute, false)
 
 # 2D Constructor from input dimensions
 function CouplingLayerHINT(n_in::Int64, n_hidden::Int64; logdet=false, permute="none",

--- a/src/layers/invertible_layer_hint.jl
+++ b/src/layers/invertible_layer_hint.jl
@@ -50,7 +50,7 @@ export CouplingLayerHINT, CouplingLayerHINT3D
 
  See also: [`CouplingLayerBasic`](@ref), [`ResidualBlock`](@ref), [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-mutable struct CouplingLayerHINT <: NeuralNetLayer
+mutable struct CouplingLayerHINT <: InvertibleNetwork
     CL::AbstractArray{CouplingLayerBasic, 1}
     C::Union{Conv1x1, Nothing}
     logdet::Bool

--- a/src/layers/invertible_layer_hyperbolic.jl
+++ b/src/layers/invertible_layer_hyperbolic.jl
@@ -53,7 +53,7 @@ Create an invertible hyperbolic coupling layer.
 
  See also: [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-struct HyperbolicLayer <: NeuralNetLayer
+struct HyperbolicLayer <: InvertibleNetwork
     W::Parameter
     b::Parameter
     α::Float32

--- a/src/layers/invertible_layer_irim.jl
+++ b/src/layers/invertible_layer_irim.jl
@@ -57,7 +57,7 @@ or
 
  See also: [`Conv1x1`](@ref), [`ResidualBlock!`](@ref), [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-struct CouplingLayerIRIM <: NeuralNetLayer
+struct CouplingLayerIRIM <: InvertibleNetwork
     C::Conv1x1
     RB::Union{ResidualBlock, FluxBlock}
 end

--- a/src/layers/invertible_layer_template.jl
+++ b/src/layers/invertible_layer_template.jl
@@ -18,7 +18,7 @@ export AffineLayer
 # parameters of our layer (in this case S and B) or any other building blocks that
 # you want to use in your layer (for example 1x1 convolutions). However, in this
 # case we only have parameters S and B.
-struct AffineLayer <: NeuralNetLayer
+struct AffineLayer <: InvertibleNetwork
     S::Parameter    # trainable parameters are defined as Parameters.
     B::Parameter    # both S and B have two fields: S.data and S.grad
     logdet::Bool    # bool to indicate whether you want to compute the logdet

--- a/src/layers/layer_affine.jl
+++ b/src/layers/layer_affine.jl
@@ -36,7 +36,7 @@ export AffineLayer
 
  See also: [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-struct AffineLayer <: NeuralNetLayer
+struct AffineLayer <: InvertibleNetwork
     s::Parameter
     b::Parameter
     logdet::Bool

--- a/src/layers/layer_flux_block.jl
+++ b/src/layers/layer_flux_block.jl
@@ -29,7 +29,7 @@ export FluxBlock
 
  See also:  [`Chain`](@ref), [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-mutable struct FluxBlock <: NeuralNetLayer
+mutable struct FluxBlock <: InvertibleNetwork
     model::Chain
     params::Array{Parameter, 1}
 end

--- a/src/layers/layer_flux_block.jl
+++ b/src/layers/layer_flux_block.jl
@@ -29,7 +29,7 @@ export FluxBlock
 
  See also:  [`Chain`](@ref), [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-mutable struct FluxBlock <: InvertibleNetwork
+mutable struct FluxBlock <: NeuralNetwork
     model::Chain
     params::Array{Parameter, 1}
 end

--- a/src/layers/layer_residual_block.jl
+++ b/src/layers/layer_residual_block.jl
@@ -64,7 +64,7 @@ or
 
  See also: [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-struct ResidualBlock <: NeuralNetLayer
+struct ResidualBlock <: InvertibleNetwork
     W1::Parameter
     W2::Parameter
     W3::Parameter

--- a/src/layers/layer_residual_block.jl
+++ b/src/layers/layer_residual_block.jl
@@ -64,7 +64,7 @@ or
 
  See also: [`get_params`](@ref), [`clear_grad!`](@ref)
 """
-struct ResidualBlock <: InvertibleNetwork
+struct ResidualBlock <: NeuralNetwork
     W1::Parameter
     W2::Parameter
     W3::Parameter

--- a/src/layers/learnable_squeezer.jl
+++ b/src/layers/learnable_squeezer.jl
@@ -1,0 +1,146 @@
+# Learnable up-/down-sampling from Etmann et al., 2020, https://arxiv.org/abs/2005.05220
+# The Frechet derivative of the matrix exponential is from Al-Mohy and Higham, 2009, https://epubs.siam.org/doi/10.1137/080716426
+
+export LearnableSqueezer
+
+mutable struct LearnableSqueezer <: InvertibleNetwork
+    stencil_pars::Parameter
+    pars2mat_idx
+    stencil_size
+    stencil::Union{AbstractArray,Nothing}
+    cdims::Union{DenseConvDims,Nothing}
+    logdet::Bool
+    reset::Bool
+    log_mat::Union{AbstractArray,Nothing}
+end
+
+@Flux.functor LearnableSqueezer
+
+
+# Constructor
+
+function LearnableSqueezer(stencil_size::Integer...; logdet::Bool=false)
+
+    σ = prod(stencil_size)
+    stencil_pars = vec2par(randn(Float32, div(σ*(σ-1), 2)), (div(σ*(σ-1), 2), ))
+    pars2mat_idx = _skew_symmetric_indices(σ)
+    return LearnableSqueezer(stencil_pars, pars2mat_idx, stencil_size, nothing, nothing, logdet, true, nothing)
+
+end
+
+
+# Forward/inverse/backward
+
+function forward(X::AbstractArray{T,N}, C::LearnableSqueezer; logdet::Union{Nothing,Bool}=nothing) where {T,N}
+    isnothing(logdet) && (logdet = C.logdet)
+
+    # Compute exponential stencil
+    if C.reset
+        _compute_exponential_stencil!(C, size(X, N-1); set_log=true)
+        C.cdims = DenseConvDims(size(X), size(C.stencil); stride=C.stencil_size)
+        C.reset = false
+    end
+
+    # Convolution
+    X = conv(X, C.stencil, C.cdims)
+
+    return logdet ? (X, convert(T, 0)) : X
+
+end
+
+function inverse(Y::AbstractArray{T,N}, C::LearnableSqueezer; logdet::Union{Nothing,Bool}=nothing) where {T,N}
+    isnothing(logdet) && (logdet = C.logdet)
+    C.reset && throw(ArgumentError("The learnable squeezer must be evaluated forward first!"))
+
+    # Convolution (adjoint)
+    Y = ∇conv_data(Y, C.stencil, C.cdims)
+
+    return logdet ? (Y, convert(T, 0)) : Y
+
+end
+
+function backward(ΔY::AbstractArray{T,N}, Y::AbstractArray{T,N}, C::LearnableSqueezer; set_grad::Bool=true, trigger_recompute::Bool=true) where {T,N}
+    C.reset && throw(ArgumentError("The learnable squeezer must be evaluated forward first!"))
+
+   # Convolution (adjoint)
+    X  = ∇conv_data(Y,  C.stencil, C.cdims)
+    ΔX = ∇conv_data(ΔY, C.stencil, C.cdims)
+
+    # Parameter gradient
+    Δstencil = _mat2stencil_adjoint(∇conv_filter(X, ΔY, C.cdims), C.stencil_size, size(X, N-1))
+    ΔA = _Frechet_exponential(C.log_mat', Δstencil)
+    Δstencil_pars = ΔA[C.pars2mat_idx[1]]-ΔA[C.pars2mat_idx[2]]
+    set_grad && (C.stencil_pars.grad = Δstencil_pars)
+
+    # Trigger recomputation
+    trigger_recompute && (C.reset = true)
+
+    return set_grad ? (ΔX, X) : (ΔX, Δstencil_pars, X)
+
+end
+
+
+# Internal utilities for LearnableSqueezer
+
+function _compute_exponential_stencil!(C::LearnableSqueezer, nc::Integer; set_log::Bool=false)
+    n = prod(C.stencil_size)
+    log_mat = _pars2skewsymm(C.stencil_pars.data, C.pars2mat_idx, n)
+    C.stencil = _mat2stencil(_exponential(log_mat), C.stencil_size, nc)
+    set_log && (C.log_mat = log_mat)
+end
+
+function _mat2stencil(A::AbstractMatrix{T}, k::NTuple{N,Integer}, nc::Integer) where {T,N}
+    stencil = similar(A, k..., nc, k..., nc); fill!(stencil, 0)
+    @inbounds for i = 1:nc
+        selectdim(selectdim(stencil, N+1, i), 2*N+1, i) .= reshape(A, k..., k...)
+    end
+    return reshape(stencil, k..., nc, :)
+end
+
+function _mat2stencil_adjoint(stencil::AbstractArray{T}, k::NTuple{N,Integer}, nc::Integer) where {T,N}
+    stencil = reshape(stencil, k..., nc, k..., nc)
+    A = similar(stencil, prod(k), prod(k)); fill!(A, 0)
+    @inbounds for i = 1:nc
+        A .+= reshape(selectdim(selectdim(stencil, N+1, i), 2*N+1, i), prod(k), prod(k))
+    end
+    return A
+end
+
+function _pars2skewsymm(Apars::AbstractVector{T}, pars2mat_idx::NTuple{2,AbstractVector{<:Integer}}, n::Integer) where T
+    A = similar(Apars, n, n)
+    A[pars2mat_idx[1]] .=  Apars
+    A[pars2mat_idx[2]] .= -Apars
+    A[diagind(A)] .= 0
+    return A
+end
+
+function _exponential(A::AbstractMatrix{T}) where T
+    expA = copy(A)
+    exponential!(expA)
+    return expA
+end
+
+function _skew_symmetric_indices(nσ::Integer)
+    CIs = reshape(1:nσ^2, nσ, nσ)
+    idx_u = Vector{Int}(undef, 0)
+    idx_l = Vector{Int}(undef, 0)
+    for i=1:nσ, j=i+1:nσ # Indices related to (strictly) upper triangular part
+        push!(idx_u, CIs[i,j])
+    end
+    for j=1:nσ, i=j+1:nσ # Indices related to (strictly) lower triangular part
+        push!(idx_l, CIs[i,j])
+    end
+    return idx_u, idx_l
+end
+
+function _Frechet_exponential(A::AbstractMatrix{T}, ΔA::AbstractMatrix{T}; niter::Int=40) where T
+    dA = copy(ΔA)
+    Mk = copy(ΔA)
+    Apowk = copy(A)
+    @inbounds for k = 2:niter
+        Mk .= Mk*A+Apowk*ΔA; Mk ./= k
+        dA .+= Mk
+        (k < niter) && (Apowk .= Apowk*A; Apowk ./= k)
+    end
+    return dA
+end

--- a/src/layers/learnable_squeezer.jl
+++ b/src/layers/learnable_squeezer.jl
@@ -3,6 +3,37 @@
 
 export LearnableSqueezer
 
+"""
+    LS = LearnableSqueezer(stencil_size::Integer...; logdet=false, zero_init=false, reversed=false)
+
+ Create invertible down-sampling orthogonal transformation with learnable stencils. To build up-sampling operators use the `reversed` flag (or `reverse(LS)` after having initialized the learnable squeezer).
+
+ *Input*:
+
+ - `stencil_size`: N-dimensional tuple that describes the size of the squeezer stencil (typically, `(2,2)` or `(2,2,2)`)
+
+ - `logdet`: flag for logdet computation (*note*, in either cases `logdet=0`!)
+
+ - `zero_init`: flag for initializing the learnable squeezer as a [`ShuffleLayer`](@ref)
+
+ - `reversed`: flag for constructing down-sampling (`reversed=false`) or up-sampling operators (`reversed=false`)
+
+ *Output*:
+
+ - `LS`: invertible learnable squeezer
+
+ *Usage:*
+
+ - Forward mode: `Y, logdet = LS.forward(X)` (if constructed with `logdet=true`)
+
+ - Inverse mode: `X = LS.inverse(Y)`
+
+ - Backward mode: `ΔX, X = LS.backward(ΔY, Y)`
+
+ *Trainable parameters:*
+
+ - `LS.stencil_pars`: they represent the upper triangular part of a skew-symmetric matrix of size `(prod(stencil_size), prod(stencil_size))`
+"""
 mutable struct LearnableSqueezer <: InvertibleNetwork
 
     # Stencil-related fields

--- a/src/utils/dimensionality_operations.jl
+++ b/src/utils/dimensionality_operations.jl
@@ -9,7 +9,7 @@ export ShuffleLayer, WaveletLayer, HaarLayer
 ###############################################################################
 # Custom type for squeezer functions
 
-struct Squeezer
+struct Squeezer <: InvertibleFunction
     forward::Function
     inverse::Function
 end
@@ -477,7 +477,7 @@ end
 
 # Split and reshape 1D vector Y in latent space back to states Zi
 # where Zi is the split tensor at each multiscale level.
-function split_states(Y::AbstractVector{T}, Z_dims; L_net=2) where {T, N}
+function split_states(Y::AbstractVector{T}, Z_dims; L_net=2) where T
     L = length(Z_dims) + 1
     inds = cumsum([1, [prod(Z_dims[j]) for j=1:L-1]...])
     Z_save = [reshape(Y[inds[j]:inds[j+1]-1], xy_dims(Z_dims[j], Val(j==L), Val(length(Z_dims[j])))) for j=1:L-1]

--- a/src/utils/dimensionality_operations.jl
+++ b/src/utils/dimensionality_operations.jl
@@ -9,7 +9,7 @@ export ShuffleLayer, WaveletLayer, HaarLayer
 ###############################################################################
 # Custom type for squeezer functions
 
-struct Squeezer <: InvertibleFunction
+struct Squeezer
     forward::Function
     inverse::Function
 end

--- a/src/utils/invertible_network_sequential.jl
+++ b/src/utils/invertible_network_sequential.jl
@@ -54,15 +54,15 @@ function ∘(net1::ComposedInvertibleNetwork, net2::ComposedInvertibleNetwork)
     return Composition(cat(net1.layers[end:-1:1], net2.layers[end:-1:1]; dims=1)...)
 end
 
-function ∘(net1::Union{InvertibleNetwork, InvertibleNetwork}, net2::Union{InvertibleNetwork, InvertibleNetwork})
+function ∘(net1::NeuralNetwork, net2::NeuralNetwork)
     return Composition(cat(net1, net2; dims=1)...)
 end
 
-function ∘(net1::Union{InvertibleNetwork, InvertibleNetwork}, net2::ComposedInvertibleNetwork)
+function ∘(net1::NeuralNetwork, net2::ComposedInvertibleNetwork)
     return Composition(cat(net1, net2.layers[end:-1:1]; dims=1)...)
 end
 
-function ∘(net1::ComposedInvertibleNetwork, net2::Union{InvertibleNetwork, InvertibleNetwork})
+function ∘(net1::ComposedInvertibleNetwork, net2::NeuralNetwork)
     return Composition(cat(net1.layers[end:-1:1], net2; dims=1)...)
 end
 

--- a/src/utils/invertible_network_sequential.jl
+++ b/src/utils/invertible_network_sequential.jl
@@ -21,7 +21,7 @@ function Composition(layer...)
 
     # Initializing output
     depth = length(layer)
-    net_array = Array{Invertible, 1}(undef, depth)
+    net_array = Array{InvertibleNetwork, 1}(undef, depth)
     logdet_array = Array{Bool, 1}(undef, depth)
     logdet = false
     npars = Array{Int64, 1}(undef, depth)

--- a/src/utils/invertible_network_sequential.jl
+++ b/src/utils/invertible_network_sequential.jl
@@ -6,7 +6,7 @@ export ComposedInvertibleNetwork, Composition
 import Base.length, Base.∘
 
 struct ComposedInvertibleNetwork <: InvertibleNetwork
-    layers::Array{T, 1} where {T <: Invertible}
+    layers::Array{T, 1} where {T <: InvertibleNetwork}
     logdet_array::Array{Bool, 1}
     logdet::Bool
     npars::Array{Int64, 1}
@@ -54,15 +54,15 @@ function ∘(net1::ComposedInvertibleNetwork, net2::ComposedInvertibleNetwork)
     return Composition(cat(net1.layers[end:-1:1], net2.layers[end:-1:1]; dims=1)...)
 end
 
-function ∘(net1::Union{NeuralNetLayer, InvertibleNetwork}, net2::Union{NeuralNetLayer, InvertibleNetwork})
+function ∘(net1::Union{InvertibleNetwork, InvertibleNetwork}, net2::Union{InvertibleNetwork, InvertibleNetwork})
     return Composition(cat(net1, net2; dims=1)...)
 end
 
-function ∘(net1::Union{NeuralNetLayer, InvertibleNetwork}, net2::ComposedInvertibleNetwork)
+function ∘(net1::Union{InvertibleNetwork, InvertibleNetwork}, net2::ComposedInvertibleNetwork)
     return Composition(cat(net1, net2.layers[end:-1:1]; dims=1)...)
 end
 
-function ∘(net1::ComposedInvertibleNetwork, net2::Union{NeuralNetLayer, InvertibleNetwork})
+function ∘(net1::ComposedInvertibleNetwork, net2::Union{InvertibleNetwork, InvertibleNetwork})
     return Composition(cat(net1.layers[end:-1:1], net2; dims=1)...)
 end
 

--- a/src/utils/jacobian.jl
+++ b/src/utils/jacobian.jl
@@ -11,22 +11,22 @@ export Jacobian
 
 struct JacobianInvertibleNetwork{T} <: joAbstractLinearOperator{T, T}
     name::String
-    n::Int64
-    m::Int64
+    n::Integer
+    m::Integer
     fop::Function
     fop_T::Function
-    N::Invertible
+    N::InvertibleNetwork
     X::AbstractArray{T}
     Y::Union{Nothing, AbstractArray{T}}
 end
 
 struct JacobianInvertibleNetworkAdjoint{T} <: joAbstractLinearOperator{T, T}
     name::String
-    n::Int64
-    m::Int64
+    n::Integer
+    m::Integer
     fop::Function
     fop_T::Function
-    N::Union{NeuralNetLayer, InvertibleNetwork}
+    N::InvertibleNetwork
     X::AbstractArray{T}
     Y::Union{Nothing, AbstractArray{T}}
 end
@@ -34,7 +34,7 @@ end
 
 ## Constructor
 
-function Jacobian(N::Union{InvertibleNetwork, NeuralNetLayer}, X::AbstractArray{T};
+function Jacobian(N::InvertibleNetwork, X::AbstractArray{T};
                   Y::Union{Nothing, AbstractArray{T}}=nothing, save_Y::Bool=true,
                   io_mode::String="θ↦Y", name::String="Jacobian") where T
 
@@ -50,7 +50,7 @@ function Jacobian(N::Union{InvertibleNetwork, NeuralNetLayer}, X::AbstractArray{
     ((io_mode == "X×θ↦Y") || (io_mode == "X×θ↦Y")) && (n += m)
 
     # Forward evaluation
-    function fop(ΔX::Union{Nothing, AbstractArray{T}}, Δθ::Array{Parameter, 1}) where T
+    function fop(ΔX::Union{Nothing, AbstractArray{T}}, Δθ::AbstractVector{<:Parameter}) where T
         isnothing(ΔX) && (ΔX = cuzeros(X, size(X)...))
         out = N.jacobian(ΔX, Δθ, X)
         ((io_mode == "θ↦Y") || (io_mode == "X×θ↦Y")) && (return out[1])
@@ -90,7 +90,7 @@ end
 
 *(J::JacobianInvertibleNetwork{T}, Δθ::Array{Parameter,1}) where T = J.fop(nothing, Δθ)
 
-function *(J::JacobianInvertibleNetwork{T}, input::Tuple{AbstractArray{T2}, Array{Parameter,1}}) where {T, T2}
+function *(J::JacobianInvertibleNetwork{T}, input::Tuple{AbstractArray{T2}, AbstractVector{<:Parameter}}) where {T, T2}
     return J.fop(jo_convert(T, input[1], false), input[2])
 end
 

--- a/src/utils/neuralnet.jl
+++ b/src/utils/neuralnet.jl
@@ -56,7 +56,7 @@ input_type(x::Tuple) = eltype(x[1])
 # For networks and layers not needing the tag
 tag_as_reversed!(I::InvertibleNetwork, ::Bool) = I
 
-reverse(N::InvertibleNetwork) = Reversed(tag_as_reversed!(deepcopy(N), true))
+reverse(N::InvertibleNetwork) = ReversedNetwork(tag_as_reversed!(deepcopy(N), true))
 reverse(RL::ReversedNetwork) = tag_as_reversed!(deepcopy(RL.I), false)
 
 """
@@ -128,6 +128,9 @@ end
 function set_params!(N::InvertibleNetwork, θnew::AbstractVector{<:Any})
     set_params!(get_params(N), θnew)
 end
+
+# Set parameters for reversed networks
+set_params!(Nrev::ReversedNetwork, θnew::AbstractVector{<:Parameter}) = set_params!(Nrev.I, θnew)
 
 # Make Invertible nets callable objects
 (net::InvertibleNetwork)(X::AbstractArray{T,N} where {T, N}) = forward_net(net, X, getfield.(get_params(net), :data))

--- a/src/utils/neuralnet.jl
+++ b/src/utils/neuralnet.jl
@@ -79,7 +79,7 @@ function get_params(I::InvertibleNetwork)
     params
 end
 
-get_params(::Nothing) = Array{Parameter}(undef, 0)
+get_params(::Any) = Array{Parameter}(undef, 0)
 get_params(A::AbstractArray{T}) where {T <: Union{InvertibleNetwork, Nothing}} = vcat([get_params(A[i]) for i in 1:length(A)]...)
 get_params(A::AbstractMatrix{T}) where {T <: Union{InvertibleNetwork, Nothing}} = vcat([get_params(A[i, j]) for i=1:size(A, 1) for j in 1:size(A, 2)]...)
 get_params(RN::ReversedNetwork) = get_params(RN.I)

--- a/src/utils/neuralnet.jl
+++ b/src/utils/neuralnet.jl
@@ -10,6 +10,8 @@ struct ReversedNetwork <: InvertibleNetwork
     I::InvertibleNetwork
 end
 
+@Flux.functor ReversedNetwork
+
 # Simple display
 Base.show(io::IO, m::NeuralNetwork) = print(io, typeof(m))
 Base.display(m::NeuralNetwork) = println(typeof(m))

--- a/src/utils/neuralnet.jl
+++ b/src/utils/neuralnet.jl
@@ -2,7 +2,8 @@ export InvertibleNetwork
 export get_grads
 
 # Invertible network abstract type
-abstract type InvertibleNetwork end
+abstract type NeuralNetwork end
+abstract type InvertibleNetwork <: NeuralNetwork end
 
 # Reversed invertible network type (concrete)
 struct ReversedNetwork <: InvertibleNetwork
@@ -10,8 +11,8 @@ struct ReversedNetwork <: InvertibleNetwork
 end
 
 # Simple display
-Base.show(io::IO, m::InvertibleNetwork) = print(io, typeof(m))
-Base.display(m::InvertibleNetwork) = println(typeof(m))
+Base.show(io::IO, m::NeuralNetwork) = print(io, typeof(m))
+Base.display(m::NeuralNetwork) = println(typeof(m))
 
 # Propagation modes
 _INet_modes = [:forward, :inverse, :backward, :backward_inv, :inverse_Y, :forward_Y,
@@ -27,14 +28,14 @@ function _predefined_mode(obj, sym::Symbol, args...; kwargs...)
 end
 
 # Base getproperty
-getproperty(I::InvertibleNetwork, s::Symbol) = _get_property(I, Val{s}())
+getproperty(I::NeuralNetwork, s::Symbol) = _get_property(I, Val{s}())
 
-_get_property(I::InvertibleNetwork, ::Val{s}) where {s} = getfield(I, s)
+_get_property(I::NeuralNetwork, ::Val{s}) where {s} = getfield(I, s)
 _get_property(R::ReversedNetwork, ::Val{:I}) = getfield(R, :I)
 _get_property(R::ReversedNetwork, ::Val{s}) where s = _get_property(R.I, Val{s}())
 
 for m ∈ _INet_modes
-    @eval _get_property(I::InvertibleNetwork, ::Val{$(Meta.quot(m))}) = (args...; kwargs...) -> _predefined_mode(I, $(Meta.quot(m)), args...; kwargs...)
+    @eval _get_property(I::NeuralNetwork, ::Val{$(Meta.quot(m))}) = (args...; kwargs...) -> _predefined_mode(I, $(Meta.quot(m)), args...; kwargs...)
 end
 
 for (m, k) ∈ _RNet_modes
@@ -42,7 +43,7 @@ for (m, k) ∈ _RNet_modes
 end
 
 # Type conversions
-function convert_params!(::Type{T}, obj::InvertibleNetwork) where T
+function convert_params!(::Type{T}, obj::NeuralNetwork) where T
     for p ∈ get_params(obj)
         convert_param!(T, p)
     end
@@ -59,13 +60,13 @@ reverse(N::InvertibleNetwork) = ReversedNetwork(tag_as_reversed!(deepcopy(N), tr
 reverse(RL::ReversedNetwork) = tag_as_reversed!(deepcopy(RL.I), false)
 
 """
-    P = get_params(NL::InvertibleNetwork)
+    P = get_params(NL::NeuralNetwork)
 
  Returns a cell array of all parameters in the network or layer. Each cell
  entry contains a reference to the original parameter; i.e. modifying
  the paramters in `P`, modifies the parameters in `NL`.
 """
-function get_params(I::InvertibleNetwork)
+function get_params(I::NeuralNetwork)
     params = Vector{Parameter}(undef, 0)
     for (f, tp) ∈ zip(fieldnames(typeof(I)), typeof(I).types)
         p = getfield(I, f)
@@ -79,52 +80,52 @@ function get_params(I::InvertibleNetwork)
 end
 
 get_params(::Any) = Array{Parameter}(undef, 0)
-get_params(A::AbstractArray{T}) where {T <: Union{InvertibleNetwork, Nothing}} = vcat([get_params(A[i]) for i in 1:length(A)]...)
-get_params(A::AbstractMatrix{T}) where {T <: Union{InvertibleNetwork, Nothing}} = vcat([get_params(A[i, j]) for i=1:size(A, 1) for j in 1:size(A, 2)]...)
+get_params(A::AbstractArray{T}) where {T <: Union{NeuralNetwork, Nothing}} = vcat([get_params(A[i]) for i in 1:length(A)]...)
+get_params(A::AbstractMatrix{T}) where {T <: Union{NeuralNetwork, Nothing}} = vcat([get_params(A[i, j]) for i=1:size(A, 1) for j in 1:size(A, 2)]...)
 get_params(RN::ReversedNetwork) = get_params(RN.I)
 
 # reset! parameters
 """
-    P = reset!(NL::InvertibleNetwork)
+    P = reset!(NL::NeuralNetwork)
 
  Resets the data of all the parameters in NL
 """
-function reset!(I::InvertibleNetwork)
+function reset!(I::NeuralNetwork)
     for p ∈ get_params(I)
         p.data = nothing
     end
 end
 
-reset!(AI::AbstractArray{<:InvertibleNetwork}) = for I ∈ AI reset!(I) end
+reset!(AI::AbstractArray{<:NeuralNetwork}) = for I ∈ AI reset!(I) end
 
 # Clear grad functionality for reversed layers/networks
 """
-    P = clear_grad!(NL::InvertibleNetwork)
+    P = clear_grad!(NL::NeuralNetwork)
 
  Resets the gradient of all the parameters in NL
 """
-clear_grad!(I::InvertibleNetwork) = clear_grad!(get_params(I))
+clear_grad!(I::NeuralNetwork) = clear_grad!(get_params(I))
 
 # Get gradients
 """
-    P = get_grads(NL::InvertibleNetwork)
+    P = get_grads(NL::NeuralNetwork)
 
  Returns a cell array of all parameters gradients in the network or layer. Each cell
  entry contains a reference to the original parameter's gradient; i.e. modifying
  the paramters in `P`, modifies the parameters in `NL`.
 """
-get_grads(I::InvertibleNetwork) = [Parameter(p.grad) for p ∈ get_params(I)]
-get_grads(A::AbstractArray{T}) where {T <: Union{InvertibleNetwork, Nothing}} = vcat([get_grads(A[i]) for i in 1:length(A)]...)
+get_grads(I::NeuralNetwork) = [Parameter(p.grad) for p ∈ get_params(I)]
+get_grads(A::AbstractArray{T}) where {T <: Union{NeuralNetwork, Nothing}} = vcat([get_grads(A[i]) for i in 1:length(A)]...)
 get_grads(RL::ReversedNetwork)= get_grads(RL.I)
 get_grads(::Nothing) = []
 
 # Set parameters
-function set_params!(N::InvertibleNetwork, θnew::AbstractVector{<:Parameter})
+function set_params!(N::NeuralNetwork, θnew::AbstractVector{<:Parameter})
     set_params!(get_params(N), θnew)
 end
 
 # Set parameters with BSON loaded params
-function set_params!(N::InvertibleNetwork, θnew::AbstractVector{<:Any})
+function set_params!(N::NeuralNetwork, θnew::AbstractVector{<:Any})
     set_params!(get_params(N), θnew)
 end
 
@@ -132,9 +133,9 @@ end
 set_params!(Nrev::ReversedNetwork, θnew::AbstractVector{<:Parameter}) = set_params!(Nrev.I, θnew)
 
 # Make Invertible nets callable objects
-(net::InvertibleNetwork)(X::AbstractArray{T,N} where {T, N}) = forward_net(net, X, getfield.(get_params(net), :data))
-forward_net(net::InvertibleNetwork, X::AbstractArray{T,N}, ::Any) where {T, N} = net.forward(X)
+(net::NeuralNetwork)(X::AbstractArray{T,N} where {T, N}) = forward_net(net, X, getfield.(get_params(net), :data))
+forward_net(net::NeuralNetwork, X::AbstractArray{T,N}, ::Any) where {T, N} = net.forward(X)
 
 # Make conditional Invertible nets callable objects
-(net::InvertibleNetwork)(X::AbstractArray{T,N}, Y::AbstractArray{T,N}) where {T, N} = forward_net(net, X, Y, getfield.(get_params(net), :data))
-forward_net(net::InvertibleNetwork, X::AbstractArray{T,N}, Y::AbstractArray{T,N}, ::Any) where {T, N} = net.forward(X,Y)
+(net::NeuralNetwork)(X::AbstractArray{T,N}, Y::AbstractArray{T,N}) where {T, N} = forward_net(net, X, Y, getfield.(get_params(net), :data))
+forward_net(net::NeuralNetwork, X::AbstractArray{T,N}, Y::AbstractArray{T,N}, ::Any) where {T, N} = net.forward(X,Y)

--- a/src/utils/neuralnet.jl
+++ b/src/utils/neuralnet.jl
@@ -2,8 +2,7 @@ export InvertibleNetwork
 export get_grads
 
 # Invertible network abstract type
-abstract type InvertibleFunction end
-abstract type InvertibleNetwork <: InvertibleFunction end
+abstract type InvertibleNetwork end
 
 # Reversed invertible network type (concrete)
 struct ReversedNetwork <: InvertibleNetwork

--- a/src/utils/neuralnet.jl
+++ b/src/utils/neuralnet.jl
@@ -1,20 +1,18 @@
-export NeuralNetLayer, InvertibleNetwork, ReverseLayer, ReverseNetwork
+export InvertibleNetwork
 export get_grads
 
-abstract type Invertible end
+# Invertible network abstract type
+abstract type InvertibleFunction end
+abstract type InvertibleNetwork <: InvertibleFunction end
 
-# Base Layer and network types with property getters
-abstract type NeuralNetLayer <: Invertible end
-abstract type InvertibleNetwork <: Invertible end
-
-# Concrete reversed types
-struct Reversed <: Invertible
-    I::Invertible
+# Reversed invertible network type (concrete)
+struct ReversedNetwork <: InvertibleNetwork
+    I::InvertibleNetwork
 end
 
 # Simple display
-Base.show(io::IO, m::Invertible) = print(io, typeof(m))
-Base.display(m::Invertible) = println(typeof(m))
+Base.show(io::IO, m::InvertibleNetwork) = print(io, typeof(m))
+Base.display(m::InvertibleNetwork) = println(typeof(m))
 
 # Propagation modes
 _INet_modes = [:forward, :inverse, :backward, :backward_inv, :inverse_Y, :forward_Y,
@@ -30,22 +28,22 @@ function _predefined_mode(obj, sym::Symbol, args...; kwargs...)
 end
 
 # Base getproperty
-getproperty(I::Invertible, s::Symbol) = _get_property(I, Val{s}())
+getproperty(I::InvertibleNetwork, s::Symbol) = _get_property(I, Val{s}())
 
-_get_property(I::Invertible, ::Val{s}) where {s} = getfield(I, s)
-_get_property(R::Reversed, ::Val{:I}) = getfield(R, :I)
-_get_property(R::Reversed, ::Val{s}) where s = _get_property(R.I, Val{s}())
+_get_property(I::InvertibleNetwork, ::Val{s}) where {s} = getfield(I, s)
+_get_property(R::ReversedNetwork, ::Val{:I}) = getfield(R, :I)
+_get_property(R::ReversedNetwork, ::Val{s}) where s = _get_property(R.I, Val{s}())
 
 for m ∈ _INet_modes
-    @eval _get_property(I::Union{InvertibleNetwork,NeuralNetLayer}, ::Val{$(Meta.quot(m))}) = (args...; kwargs...) -> _predefined_mode(I, $(Meta.quot(m)), args...; kwargs...)
+    @eval _get_property(I::InvertibleNetwork, ::Val{$(Meta.quot(m))}) = (args...; kwargs...) -> _predefined_mode(I, $(Meta.quot(m)), args...; kwargs...)
 end
 
 for (m, k) ∈ _RNet_modes
-    @eval _get_property(R::Reversed, ::Val{$(Meta.quot(m))}) = _get_property(R.I, Val{$(Meta.quot(k))}())
+    @eval _get_property(R::ReversedNetwork, ::Val{$(Meta.quot(m))}) = _get_property(R.I, Val{$(Meta.quot(k))}())
 end
 
 # Type conversions
-function convert_params!(::Type{T}, obj::Invertible) where T
+function convert_params!(::Type{T}, obj::InvertibleNetwork) where T
     for p ∈ get_params(obj)
         convert_param!(T, p)
     end
@@ -56,20 +54,19 @@ input_type(x::Tuple) = eltype(x[1])
 
 # Reverse
 # For networks and layers not needing the tag
-tag_as_reversed!(I::Invertible, ::Bool) = I
+tag_as_reversed!(I::InvertibleNetwork, ::Bool) = I
 
-reverse(L::NeuralNetLayer) = Reversed(tag_as_reversed!(deepcopy(L), true))
 reverse(N::InvertibleNetwork) = Reversed(tag_as_reversed!(deepcopy(N), true))
-reverse(RL::Reversed) = tag_as_reversed!(deepcopy(RL.I), false)
+reverse(RL::ReversedNetwork) = tag_as_reversed!(deepcopy(RL.I), false)
 
 """
-    P = get_params(NL::Invertible)
+    P = get_params(NL::InvertibleNetwork)
 
  Returns a cell array of all parameters in the network or layer. Each cell
  entry contains a reference to the original parameter; i.e. modifying
  the paramters in `P`, modifies the parameters in `NL`.
 """
-function get_params(I::Invertible)
+function get_params(I::InvertibleNetwork)
     params = Vector{Parameter}(undef, 0)
     for (f, tp) ∈ zip(fieldnames(typeof(I)), typeof(I).types)
         p = getfield(I, f)
@@ -82,60 +79,60 @@ function get_params(I::Invertible)
     params
 end
 
-get_params(x) = Array{Parameter}(undef, 0)
-get_params(A::Array{T}) where T<:Union{Invertible, Nothing} = vcat([get_params(A[i]) for i in 1:length(A)]...)
-get_params(A::Matrix{T}) where T<:Union{Invertible, Nothing} = vcat([get_params(A[i, j]) for i=1:size(A, 1) for j in 1:size(A, 2)]...)
-get_params(RN::Reversed) = get_params(RN.I)
+get_params(::Nothing) = Array{Parameter}(undef, 0)
+get_params(A::AbstractArray{T}) where {T <: Union{InvertibleNetwork, Nothing}} = vcat([get_params(A[i]) for i in 1:length(A)]...)
+get_params(A::AbstractMatrix{T}) where {T <: Union{InvertibleNetwork, Nothing}} = vcat([get_params(A[i, j]) for i=1:size(A, 1) for j in 1:size(A, 2)]...)
+get_params(RN::ReversedNetwork) = get_params(RN.I)
 
 # reset! parameters
 """
-    P = reset!(NL::Invertible)
+    P = reset!(NL::InvertibleNetwork)
 
  Resets the data of all the parameters in NL
 """
-function reset!(I::Invertible)
+function reset!(I::InvertibleNetwork)
     for p ∈ get_params(I)
         p.data = nothing
     end
 end
 
-reset!(AI::Array{<:Invertible}) = for I ∈ AI reset!(I) end
+reset!(AI::AbstractArray{<:InvertibleNetwork}) = for I ∈ AI reset!(I) end
 
 # Clear grad functionality for reversed layers/networks
 """
-    P = clear_grad!(NL::Invertible)
+    P = clear_grad!(NL::InvertibleNetwork)
 
  Resets the gradient of all the parameters in NL
 """
-clear_grad!(I::Invertible) = clear_grad!(get_params(I))
+clear_grad!(I::InvertibleNetwork) = clear_grad!(get_params(I))
 
 # Get gradients
 """
-    P = get_grads(NL::Invertible)
+    P = get_grads(NL::InvertibleNetwork)
 
  Returns a cell array of all parameters gradients in the network or layer. Each cell
  entry contains a reference to the original parameter's gradient; i.e. modifying
  the paramters in `P`, modifies the parameters in `NL`.
 """
-get_grads(I::Invertible) = [Parameter(p.grad) for p ∈ get_params(I)]
-get_grads(A::Array{Union{Invertible, Nothing}}) = vcat([get_grads(A[i]) for i in 1:length(A)]...)
-get_grads(RL::Reversed)= get_grads(RL.I)
+get_grads(I::InvertibleNetwork) = [Parameter(p.grad) for p ∈ get_params(I)]
+get_grads(A::AbstractArray{T}) where {T <: Union{InvertibleNetwork, Nothing}} = vcat([get_grads(A[i]) for i in 1:length(A)]...)
+get_grads(RL::ReversedNetwork)= get_grads(RL.I)
 get_grads(::Nothing) = []
 
 # Set parameters
-function set_params!(N::Invertible, θnew::Array{Parameter, 1})
+function set_params!(N::InvertibleNetwork, θnew::AbstractVector{<:Parameter})
     set_params!(get_params(N), θnew)
 end
 
 # Set parameters with BSON loaded params
-function set_params!(N::Invertible, θnew::Array{Any, 1})
+function set_params!(N::InvertibleNetwork, θnew::AbstractVector{<:Any})
     set_params!(get_params(N), θnew)
 end
 
-# Make invertible nets callable objects
-(net::Invertible)(X::AbstractArray{T,N} where {T, N}) = forward_net(net, X, getfield.(get_params(net), :data))
-forward_net(net::Invertible, X::AbstractArray{T,N}, ::Any) where {T, N} = net.forward(X)
+# Make Invertible nets callable objects
+(net::InvertibleNetwork)(X::AbstractArray{T,N} where {T, N}) = forward_net(net, X, getfield.(get_params(net), :data))
+forward_net(net::InvertibleNetwork, X::AbstractArray{T,N}, ::Any) where {T, N} = net.forward(X)
 
-# Make conditional invertible nets callable objects
-(net::Invertible)(X::AbstractArray{T,N}, Y::AbstractArray{T,N}) where {T, N} = forward_net(net, X, Y, getfield.(get_params(net), :data))
-forward_net(net::Invertible, X::AbstractArray{T,N}, Y::AbstractArray{T,N}, ::Any) where {T, N} = net.forward(X,Y)
+# Make conditional Invertible nets callable objects
+(net::InvertibleNetwork)(X::AbstractArray{T,N}, Y::AbstractArray{T,N}) where {T, N} = forward_net(net, X, Y, getfield.(get_params(net), :data))
+forward_net(net::InvertibleNetwork, X::AbstractArray{T,N}, Y::AbstractArray{T,N}, ::Any) where {T, N} = net.forward(X,Y)

--- a/src/utils/parameter.jl
+++ b/src/utils/parameter.jl
@@ -42,7 +42,7 @@ length(x::Parameter) = length(x.data)
 @Flux.functor Parameter
 
 """
-    clear_grad!(NL::NeuralNetLayer)
+    clear_grad!(NL::InvertibleNetwork)
 
 or
 

--- a/src/utils/parameter.jl
+++ b/src/utils/parameter.jl
@@ -46,11 +46,11 @@ length(x::Parameter) = length(x.data)
 
 or
 
-    clear_grad!(P::AbstractArray{Parameter, 1})
+    clear_grad!(P::AbstractAbstractVector{<:Parameter})
 
  Set gradients of each `Parameter` in the network layer to `nothing`.
 """
-function clear_grad!(P::AbstractArray{Parameter, 1})
+function clear_grad!(P::AbstractVector{<:Parameter})
     for j=1:length(P)
         P[j].grad = nothing
     end
@@ -60,8 +60,8 @@ function get_grads(p::Parameter)
     return Parameter(p.grad)
 end
 
-function get_grads(pvec::Array{Parameter, 1})
-    g = Array{Parameter, 1}(undef, length(pvec))
+function get_grads(pvec::AbstractVector{<:Parameter})
+    g = Vector{Parameter}(undef, length(pvec))
     for i = 1:length(pvec)
         g[i] = get_grads(pvec[i])
     end
@@ -75,13 +75,13 @@ function set_params!(pold::Parameter, pnew::Parameter)
     pold.grad = pnew.grad
 end
 
-function set_params!(pold::Array{Parameter, 1}, pnew::Array{Parameter, 1})
+function set_params!(pold::AbstractVector{<:Parameter}, pnew::AbstractVector{<:Parameter})
     for i = 1:length(pold)
         set_params!(pold[i], pnew[i])
     end
 end
 
-function set_params!(pold::Array{Parameter, 1}, pnew::Array{Any, 1})
+function set_params!(pold::AbstractVector{<:Parameter}, pnew::AbstractVector{<:Any})
     for i = 1:length(pold)
         set_params!(pold[i], pnew[i])
     end
@@ -91,75 +91,37 @@ end
 
 ## Algebraic utilities for parameters
 
-function dot(p1::Parameter, p2::Parameter)
-    return dot(p1.data, p2.data)
-end
-
-function norm(p::Parameter)
-    return norm(p.data)
-end
-
-function +(p1::Parameter, p2::Parameter)
-    return Parameter(p1.data+p2.data)
-end
-
-function +(p1::Parameter, p2::T) where {T<:Real}
-    return Parameter(p1.data+p2)
-end
-
-function +(p1::T, p2::Parameter) where {T<:Real}
-    return p2+p1
-end
-
-function -(p1::Parameter, p2::Parameter)
-    return Parameter(p1.data-p2.data)
-end
-
-function -(p1::Parameter, p2::T) where {T<:Real}
-    return Parameter(p1.data-p2)
-end
-
-function -(p1::T, p2::Parameter) where {T<:Real}
-    return -(p2-p1)
-end
-
-function -(p::Parameter)
-    return Parameter(-p.data)
-end
-
-function *(p1::Parameter, p2::T) where {T<:Real}
-    return Parameter(p1.data*p2)
-end
-
-function *(p1::T, p2::Parameter) where {T<:Real}
-    return p2*p1
-end
-
-function /(p1::Parameter, p2::T) where {T<:Real}
-    return Parameter(p1.data/p2)
-end
-
-function /(p1::T, p2::Parameter) where {T<:Real}
-    return Parameter(p1/p2.data)
-end
+dot(p1::Parameter, p2::Parameter) = dot(p1.data, p2.data)
+norm(p::Parameter) = norm(p.data)
++(p1::Parameter, p2::Parameter) = Parameter(p1.data+p2.data)
++(p1::Parameter, p2::T) where {T<:Real} = Parameter(p1.data+p2)
++(p1::T, p2::Parameter) where {T<:Real} = p2+p1
+-(p1::Parameter, p2::Parameter) = Parameter(p1.data-p2.data)
+-(p1::Parameter, p2::T) where {T<:Real} = Parameter(p1.data-p2)
+-(p1::T, p2::Parameter) where {T<:Real} = -(p2-p1)
+-(p::Parameter) = Parameter(-p.data)
+*(p1::Parameter, p2::T) where {T<:Real} = Parameter(p1.data*p2) 
+*(p1::T, p2::Parameter) where {T<:Real} = p2*p1
+/(p1::Parameter, p2::T) where {T<:Real} = Parameter(p1.data/p2)
+/(p1::T, p2::Parameter) where {T<:Real} = Parameter(p1/p2.data)
 
 # Shape manipulation
 
 par2vec(x::Parameter) = vec(x.data), size(x.data)
 
 
-function vec2par(x::AbstractArray{T, 1}, s::NTuple{N, Int64}) where {T, N}
+function vec2par(x::AbstractVector{T}, s::NTuple{N, Integer}) where {T, N}
     return Parameter(reshape(x, s))
 end
 
-function par2vec(x::Array{Parameter, 1})
+function par2vec(x::AbstractVector{<:Parameter})
     v = cat([vec(x[i].data) for i=1:length(x)]..., dims=1)
     s = cat([size(x[i].data) for i=1:length(x)]..., dims=1)
     return v, s
 end
 
-function vec2par(x::AbstractArray{T, 1}, s::Array{Any, 1}) where T
-    xpar = Array{Parameter, 1}(undef, length(s))
+function vec2par(x::AbstractVector{T}, s::AbstractVector) where T
+    xpar = AbstractVector{<:Parameter}(undef, length(s))
     idx_i = 0
     for i = 1:length(s)
         xpar[i] = vec2par(x[idx_i+1:idx_i+prod(s[i])], s[i])

--- a/src/utils/parameter.jl
+++ b/src/utils/parameter.jl
@@ -46,7 +46,7 @@ length(x::Parameter) = length(x.data)
 
 or
 
-    clear_grad!(P::AbstractAbstractVector{<:Parameter})
+    clear_grad!(P::AbstractVector{<:Parameter})
 
  Set gradients of each `Parameter` in the network layer to `nothing`.
 """
@@ -94,16 +94,16 @@ end
 dot(p1::Parameter, p2::Parameter) = dot(p1.data, p2.data)
 norm(p::Parameter) = norm(p.data)
 +(p1::Parameter, p2::Parameter) = Parameter(p1.data+p2.data)
-+(p1::Parameter, p2::T) where {T<:Real} = Parameter(p1.data+p2)
-+(p1::T, p2::Parameter) where {T<:Real} = p2+p1
++(p1::Parameter, p2::T) where {T<:Number} = Parameter(p1.data+p2)
++(p1::T, p2::Parameter) where {T<:Number} = p2+p1
 -(p1::Parameter, p2::Parameter) = Parameter(p1.data-p2.data)
--(p1::Parameter, p2::T) where {T<:Real} = Parameter(p1.data-p2)
--(p1::T, p2::Parameter) where {T<:Real} = -(p2-p1)
+-(p1::Parameter, p2::T) where {T<:Number} = Parameter(p1.data-p2)
+-(p1::T, p2::Parameter) where {T<:Number} = -(p2-p1)
 -(p::Parameter) = Parameter(-p.data)
-*(p1::Parameter, p2::T) where {T<:Real} = Parameter(p1.data*p2) 
-*(p1::T, p2::Parameter) where {T<:Real} = p2*p1
-/(p1::Parameter, p2::T) where {T<:Real} = Parameter(p1.data/p2)
-/(p1::T, p2::Parameter) where {T<:Real} = Parameter(p1/p2.data)
+*(p1::Parameter, p2::T) where {T<:Number} = Parameter(p1.data*p2) 
+*(p1::T, p2::Parameter) where {T<:Number} = p2*p1
+/(p1::Parameter, p2::T) where {T<:Number} = Parameter(p1.data/p2)
+/(p1::T, p2::Parameter) where {T<:Number} = Parameter(p1/p2.data)
 
 # Shape manipulation
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,7 +34,8 @@ layers = ["test_layers/test_residual_block.jl",
           "test_layers/test_conditional_res_block.jl",
           "test_layers/test_hyperbolic_layer.jl",
           "test_layers/test_actnorm.jl",
-          "test_layers/test_layer_affine.jl"]
+          "test_layers/test_layer_affine.jl",
+          "test_layers/test_learnable_squeezer.jl"]
 
 networks = ["test_networks/test_unrolled_loop.jl",
             "test_networks/test_generator.jl",

--- a/test/test_layers/test_learnable_squeezer.jl
+++ b/test/test_layers/test_learnable_squeezer.jl
@@ -27,6 +27,14 @@ for N = 1:3
     @test X ≈ X_ rtol=1f-6
 
 
+    # Test backward_inv/forward coherence
+    ΔX = randn(Float32, n[1:N]..., nc, batchsize) |> device
+    X  = randn(Float32, n[1:N]..., nc, batchsize) |> device
+    Y_ = C.forward(X)
+    _, Y = C.backward_inv(ΔX, X)
+    @test Y ≈ Y_ rtol=1f-6
+
+
     # Gradient test (input)
     ΔY = randn(Float32, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize) |> device
     ΔX = randn(Float32, n[1:N]..., nc, batchsize) |> device
@@ -34,6 +42,15 @@ for N = 1:3
     Y = C.forward(X)
     ΔX_, _ = C.backward(ΔY, Y)
     @test dot(ΔX, ΔX_) ≈ dot(C.forward(ΔX), ΔY) rtol=1f-4
+
+
+    # Gradient test (input, inv)
+    ΔY = randn(Float32, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize) |> device
+    ΔX = randn(Float32, n[1:N]..., nc, batchsize) |> device
+    Y = randn(Float32, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize) |> device
+    X = C.inverse(Y)
+    ΔY_, _ = C.backward_inv(ΔX, X; trigger_recompute=false)
+    @test dot(ΔY, ΔY_) ≈ dot(C.inverse(ΔY), ΔX) rtol=1f-4
 
 
     # Gradient test (parameters)
@@ -46,16 +63,39 @@ for N = 1:3
     Δθ = CUDA.randn(T, size(θ)); Δθ *= norm(θ)/norm(Δθ)
 
     t = T(1e-5)
-    C.stencil_pars.data = θ+t*Δθ/2; C.reset = true
+    set_params!(C, [Parameter(θ+t*Δθ/2)])
     Yp1 = C.forward(X)
-    C.stencil_pars.data = θ-t*Δθ/2; C.reset = true
+    set_params!(C, [Parameter(θ-t*Δθ/2)])
     Ym1 = C.forward(X)
     ΔY = (Yp1-Ym1)/t
-    C.stencil_pars.data = θ; C.reset = true
+    set_params!(C, [Parameter(θ)])
     Y = C.forward(X)
     C.backward(ΔY_, Y)
     Δθ_ = C.stencil_pars.grad
 
     @test dot(ΔY, ΔY_) ≈ dot(Δθ, Δθ_) rtol=T(1e-4)
+
+
+    # Gradient test (parameters, inv)
+    using CUDA
+    T = Float64
+    Crev = reverse(LearnableSqueezer(k[1:N]...)) |> device; Crev.stencil_pars.data = cu(Crev.stencil_pars.data)
+    Y   = CUDA.randn(T, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize)
+    ΔX_ = CUDA.randn(T, n[1:N]..., nc, batchsize)
+    θ = deepcopy(Crev.stencil_pars.data)
+    Δθ = CUDA.randn(T, size(θ)); Δθ *= norm(θ)/norm(Δθ)
+
+    t = T(1e-5)
+    set_params!(Crev, [Parameter(θ+t*Δθ/2)])
+    Xp1 = Crev.forward(Y)
+    set_params!(Crev, [Parameter(θ-t*Δθ/2)])
+    Xm1 = Crev.forward(Y)
+    ΔX = (Xp1-Xm1)/t
+    set_params!(Crev, [Parameter(θ)])
+    X = Crev.forward(Y)
+    Crev.backward(ΔX_, X)
+    Δθ_ = Crev.stencil_pars.grad
+
+    @test dot(ΔX, ΔX_) ≈ dot(Δθ, Δθ_) rtol=T(1e-4)
 
 end

--- a/test/test_layers/test_learnable_squeezer.jl
+++ b/test/test_layers/test_learnable_squeezer.jl
@@ -11,11 +11,8 @@ k = (2, 3, 4)
 
 for N = 1:3
 
-    # Initialize operator
-    C = LearnableSqueezer(k[1:N]...) |> device
-
-
     # Test invertibility
+    C = LearnableSqueezer(k[1:N]...) |> device
     X = randn(Float32, n[1:N]..., nc, batchsize) |> device
     Y = randn(Float32, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize) |> device
     @test X ≈ C.inverse(C.forward(X)) rtol=1f-6

--- a/test/test_layers/test_learnable_squeezer.jl
+++ b/test/test_layers/test_learnable_squeezer.jl
@@ -1,0 +1,64 @@
+using InvertibleNetworks, LinearAlgebra, Test, Flux, Random
+device = InvertibleNetworks.CUDA.functional() ? gpu : cpu
+Random.seed!(11)
+
+
+# Dimensions
+n = (2*17, 3*11, 4*7)
+nc = 4
+batchsize = 3
+k = (2, 3, 4)
+
+for N = 1:3
+
+    # Initialize operator
+    C = LearnableSqueezer(k[1:N]...) |> device
+
+
+    # Test invertibility
+    X = randn(Float32, n[1:N]..., nc, batchsize) |> device
+    Y = randn(Float32, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize) |> device
+    @test X ≈ C.inverse(C.forward(X)) rtol=1f-6
+    @test Y ≈ C.forward(C.inverse(Y)) rtol=1f-6
+
+
+    # Test backward/inverse coherence
+    ΔY = randn(Float32, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize) |> device
+    Y  = randn(Float32, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize) |> device
+    X_ = C.inverse(Y)
+    _, X = C.backward(ΔY, Y)
+    @test X ≈ X_ rtol=1f-6
+
+
+    # Gradient test (input)
+    ΔY = randn(Float32, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize) |> device
+    ΔX = randn(Float32, n[1:N]..., nc, batchsize) |> device
+    X  = randn(Float32, n[1:N]..., nc, batchsize) |> device
+    Y = C.forward(X)
+    ΔX_, _ = C.backward(ΔY, Y)
+    @test dot(ΔX, ΔX_) ≈ dot(C.forward(ΔX), ΔY) rtol=1f-4
+
+
+    # Gradient test (parameters)
+    using CUDA
+    T = Float64
+    C = LearnableSqueezer(k[1:N]...) |> device; C.stencil_pars.data = cu(C.stencil_pars.data)
+    X  = CUDA.randn(T, n[1:N]..., nc, batchsize)
+    ΔY_ = CUDA.randn(T, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize)
+    θ = copy(C.stencil_pars.data)
+    Δθ = CUDA.randn(T, size(θ)); Δθ *= norm(θ)/norm(Δθ)
+
+    t = T(1e-5)
+    C.stencil_pars.data = θ+t*Δθ/2; C.reset = true
+    Yp1 = C.forward(X)
+    C.stencil_pars.data = θ-t*Δθ/2; C.reset = true
+    Ym1 = C.forward(X)
+    ΔY = (Yp1-Ym1)/t
+    C.stencil_pars.data = θ; C.reset = true
+    Y = C.forward(X)
+    C.backward(ΔY_, Y)
+    Δθ_ = C.stencil_pars.grad
+
+    @test dot(ΔY, ΔY_) ≈ dot(Δθ, Δθ_) rtol=T(1e-4)
+
+end

--- a/test/test_layers/test_learnable_squeezer.jl
+++ b/test/test_layers/test_learnable_squeezer.jl
@@ -54,13 +54,12 @@ for N = 1:3
 
 
     # Gradient test (parameters)
-    using CUDA
     T = Float64
-    C = LearnableSqueezer(k[1:N]...) |> device; C.stencil_pars.data = cu(C.stencil_pars.data)
-    X  = CUDA.randn(T, n[1:N]..., nc, batchsize)
-    ΔY_ = CUDA.randn(T, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize)
+    C = LearnableSqueezer(k[1:N]...) |> device; C.stencil_pars.data = InvertibleNetworks.CUDA.cu(C.stencil_pars.data)
+    X  = InvertibleNetworks.CUDA.randn(T, n[1:N]..., nc, batchsize)
+    ΔY_ = InvertibleNetworks.CUDA.randn(T, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize)
     θ = copy(C.stencil_pars.data)
-    Δθ = CUDA.randn(T, size(θ)); Δθ *= norm(θ)/norm(Δθ)
+    Δθ = InvertibleNetworks.CUDA.randn(T, size(θ)); Δθ *= norm(θ)/norm(Δθ)
 
     t = T(1e-5)
     set_params!(C, [Parameter(θ+t*Δθ/2)])
@@ -77,13 +76,12 @@ for N = 1:3
 
 
     # Gradient test (parameters, inv)
-    using CUDA
     T = Float64
-    Crev = reverse(LearnableSqueezer(k[1:N]...)) |> device; Crev.stencil_pars.data = cu(Crev.stencil_pars.data)
-    Y   = CUDA.randn(T, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize)
-    ΔX_ = CUDA.randn(T, n[1:N]..., nc, batchsize)
+    Crev = reverse(LearnableSqueezer(k[1:N]...)) |> device; Crev.stencil_pars.data = InvertibleNetworks.CUDA.cu(Crev.stencil_pars.data)
+    Y   = InvertibleNetworks.CUDA.randn(T, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize)
+    ΔX_ = InvertibleNetworks.CUDA.randn(T, n[1:N]..., nc, batchsize)
     θ = deepcopy(Crev.stencil_pars.data)
-    Δθ = CUDA.randn(T, size(θ)); Δθ *= norm(θ)/norm(Δθ)
+    Δθ = InvertibleNetworks.CUDA.randn(T, size(θ)); Δθ *= norm(θ)/norm(Δθ)
 
     t = T(1e-5)
     set_params!(Crev, [Parameter(θ+t*Δθ/2)])

--- a/test/test_layers/test_learnable_squeezer.jl
+++ b/test/test_layers/test_learnable_squeezer.jl
@@ -49,7 +49,7 @@ for N = 1:3
     ΔX = randn(Float32, n[1:N]..., nc, batchsize) |> device
     Y = randn(Float32, div.(n, k)[1:N]..., prod(k[1:N])*nc, batchsize) |> device
     X = C.inverse(Y)
-    ΔY_, _ = C.backward_inv(ΔX, X; trigger_recompute=false)
+    ΔY_, _ = C.backward_inv(ΔX, X)
     @test dot(ΔY, ΔY_) ≈ dot(C.inverse(ΔY), ΔX) rtol=1f-4
 
 

--- a/test/test_utils/test_activations.jl
+++ b/test/test_utils/test_activations.jl
@@ -248,7 +248,6 @@ dX = X - X0
 # Gradient test Sigmoid2
 L = Sigmoid2Layer()
 function objective(X, Y)
-    print("here")
     Y0 = L.forward(X)
     ΔY = Y0 - Y
     f = .5f0*norm(ΔY)^2


### PR DESCRIPTION
Added a "learnable squeezer" layer, typically used in invertible U-nets (see Etmann, et al., 2020, https://arxiv.org/abs/2005.05220).

Some other very minor changes, the most important of which is having removed the type "InvertibleLayer" and changed it to "InvertibleNetwork". Didn't really see a need for having a separate "InvertibleLayer" type.