### PR TITLE
version bump 2.10.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InvertibleNetworks"
 uuid = "b7115f24-5f92-4794-81e8-23b0ddb121d3"
 authors = ["Philipp Witte <p.witte@ymail.com>", "Ali Siahkoohi <alisk@gatech.edu>", "Mathias Louboutin <mlouboutin3@gatech.edu>", "Gabrio Rizzuti <g.rizzuti@umcutrecht.nl>", "Rafael Orozco <rorozco@gatech.edu>", "Felix J. Herrmann <fherrmann@gatech.edu>"]
-version = "2.2.9"
+version = "2.3.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"


### PR DESCRIPTION
@rafaelorozco I'd like to bump the version so I can use conditional Glow in a package with a not-power-of-two input size.

I started making that update to the other networks (https://github.com/gbruer15/InvertibleNetworks.jl/pull/1), but I ran into issues with the Taylor gradient test failing. So I'm putting that on hold for now. I still think it is worth it to release a version with just conditional Glow working on new input sizes.